### PR TITLE
Add pytest examples, docstrings, and typed calls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,12 @@ repos:
     -   id: black
         language_version: python3
         args: ["--target-version", "py36"]
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.7.0
+    hooks:
+    -   id: isort
+        language_version: python3
+        args: ['--profile', 'black']
 -   repo: https://github.com/pycqa/flake8
     rev: 3.9.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ geo = Geoserver('http://127.0.0.1:8080/geoserver', username='admin', password='g
 geo.create_workspace(workspace='demo')
 
 # For uploading raster data to the geoserver
-geo.create_coveragestore(lyr_name='layer1', path=r'path\to\raster\file.tif', workspace='demo')
+geo.create_coveragestore(layer_name='layer1', path=r'path\to\raster\file.tif', workspace='demo')
 
 # For creating postGIS connection and publish postGIS table
-geo.create_featurestore(store_name='geo_data', workspace='demo', db='postgres', host='localhost', pg_user='postgres', pg_password='admin')
+geo.create_featurestore(store_name='geo_data', workspace='demo', db='postgres', host='localhost', pg_user='postgres',
+                        pg_password='admin')
 geo.publish_featurestore(workspace='demo', store_name='geo_data', pg_table='geodata_table_name')
 
 # For uploading SLD file and connect it with layer
@@ -43,7 +44,8 @@ geo.upload_style(path=r'path\to\sld\file.sld', workspace='demo')
 geo.publish_style(layer_name='geoserver_layer_name', style_name='sld_file_name', workspace='demo', sld_version='1.0.0')
 
 # For creating the style file for raster data dynamically and connect it with layer
-geo.create_coveragestyle(raster_path=r'path\to\raster\file.tiff', style_name='style_1', workspace='demo', color_ramp='RdYiGn')
+geo.create_coveragestyle(raster_path=r'path\to\raster\file.tiff', style_name='style_1', workspace='demo',
+                         color_ramp='RdYiGn')
 geo.publish_style(layer_name='geoserver_layer_name', style_name='raster_file_name', workspace='demo')
 
 # delete workspace

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,6 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import sphinx_rtd_theme
 
-
 # -- Project information -----------------------------------------------------
 
 project = "geoserver-rest"

--- a/geo/Calculation_gdal.py
+++ b/geo/Calculation_gdal.py
@@ -3,7 +3,7 @@ import os
 try:
     from osgeo import gdal  # noqa
 except ImportError:
-    import gdal
+    import gdal  # noqa
 
 
 def raster_value(path):
@@ -15,11 +15,11 @@ def raster_value(path):
         gtif = gdal.Open(path)
         srcband = gtif.GetRasterBand(1)
         srcband.ComputeStatistics(0)
-        N = srcband.GetMaximum() - srcband.GetMinimum() + 1
-        N = int(N)
-        min = srcband.GetMinimum()
-        max = srcband.GetMaximum()
-        result = {"N": N, "min": min, "max": max, "file_name": file_name}
+        n = srcband.GetMaximum() - srcband.GetMinimum() + 1
+        n = int(n)
+        min_value = srcband.GetMinimum()
+        max_value = srcband.GetMaximum()
+        result = {"N": n, "min": min_value, "max": max_value, "file_name": file_name}
         return result
 
     else:

--- a/geo/Calculation_gdal.py
+++ b/geo/Calculation_gdal.py
@@ -1,7 +1,7 @@
 import os
 
 try:
-    from osgeo import gdal
+    from osgeo import gdal  # noqa
 except ImportError:
     import gdal
 

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -1,8 +1,11 @@
-import pycurl
 import os
+from typing import Optional
+
+import pycurl
 import requests
-from .Style import coverage_style_xml, outline_only_xml, catagorize_xml, classified_xml
+
 from .Calculation_gdal import raster_value
+from .Style import catagorize_xml, classified_xml, coverage_style_xml, outline_only_xml
 from .supports import prepare_zip_file
 
 
@@ -132,7 +135,7 @@ class Geoserver:
         except Exception as e:
             return "reload error: {}".format(e)
 
-    def get_datastore(self, store_name: str, workspace: str = None):
+    def get_datastore(self, store_name: str, workspace: Optional[str] = None):
         """
         Return the data store in a given workspace.
 
@@ -153,7 +156,7 @@ class Geoserver:
         except Exception as e:
             return "get_datastores error: {}".format(e)
 
-    def get_datastores(self, workspace: str = None):
+    def get_datastores(self, workspace: Optional[str] = None):
         """
         List all data stores in a workspace.
 
@@ -173,7 +176,7 @@ class Geoserver:
         except Exception as e:
             return "get_datastores error: {}".format(e)
 
-    def get_coveragestore(self, coveragestore_name: str, workspace: str = None):
+    def get_coveragestore(self, coveragestore_name: str, workspace: Optional[str] = None):
         """
         Returns the store name if it exists.
         """
@@ -209,7 +212,7 @@ class Geoserver:
         except Exception as e:
             return "get_coveragestores error: {}".format(e)
 
-    def get_layer(self, layer_name: str, workspace: str = None):
+    def get_layer(self, layer_name: str, workspace: Optional[str] = None):
         """
         Returns the layer by layer name.
         """
@@ -226,7 +229,7 @@ class Geoserver:
         except Exception as e:
             return "get_layer error: {}".format(e)
 
-    def get_layers(self, workspace: str = None):
+    def get_layers(self, workspace: Optional[str] = None):
         """
         Get all the layers from geoserver
         If workspace is None, it will listout all the layers from geoserver
@@ -242,7 +245,7 @@ class Geoserver:
         except Exception as e:
             return "get_layers error: {}".format(e)
 
-    def get_layergroups(self, workspace: str = None):
+    def get_layergroups(self, workspace: Optional[str] = None):
         """
         Returns all the layer groups from geoserver.
 
@@ -263,7 +266,7 @@ class Geoserver:
         except Exception as e:
             return "get_layers error: {}".format(e)
 
-    def get_layergroup(self, layer_name: str, workspace: str = None):
+    def get_layergroup(self, layer_name: str, workspace: Optional[str] = None):
         """
         Returns the layer group by layer group name.
         """
@@ -280,7 +283,7 @@ class Geoserver:
         except Exception as e:
             return "get_layer error: {}".format(e)
 
-    def get_style(self, style_name, workspace=None):
+    def get_style(self, style_name, workspace: Optional[str] = None):
         """
         Returns the style by style name.
         """
@@ -297,7 +300,7 @@ class Geoserver:
         except Exception as e:
             return "get_style error: {}".format(e)
 
-    def get_styles(self, workspace=None):
+    def get_styles(self, workspace: Optional[str] = None):
         """
         Returns all loaded styles from geoserver.
         """
@@ -408,8 +411,8 @@ class Geoserver:
     def create_coveragestore(
         self,
         path,
-        workspace: str = None,
-        layer_name: str = None,
+        workspace: Optional[str] = None,
+        layer_name: Optional[str] = None,
         file_type: str = "GeoTIFF",
         content_type: str = "image/tiff",
         overwrite: bool = False,
@@ -420,8 +423,8 @@ class Geoserver:
         Parameters
         ----------
         path : str
-        workspace : str
-        layer_name : str
+        workspace : str, optional
+        layer_name : str, optional
             The name of coveragestore. If not provided, parsed from the file name.
         file_type : str
         content_type : str
@@ -474,7 +477,7 @@ class Geoserver:
     def create_featurestore(
         self,
         store_name: str,
-        workspace: str = None,
+        workspace: Optional[str] = None,
         db: str = "postgres",
         host: str = "localhost",
         port: int = 5432,
@@ -489,7 +492,7 @@ class Geoserver:
         Parameters
         ----------
         store_name : str
-        workspace : str
+        workspace : str, optional
         db : str
         host : str
         port : int
@@ -544,7 +547,7 @@ class Geoserver:
         except Exception as e:
             return "Error:%s" % str(e)
 
-    def create_datastore(self, name: str, path: str, workspace: str = None, overwrite: bool = False):
+    def create_datastore(self, name: str, path: str, workspace: Optional[str] = None, overwrite: bool = False):
         """
         Create a datastore within the GeoServer.
 
@@ -556,7 +559,7 @@ class Geoserver:
         path : str
             Path to shapefile (.shp) file, GeoPackage (.gpkg) file, WFS url
             (e.g. http://localhost:8080/geoserver/wfs?request=GetCapabilities) or directory containing shapefiles.
-        workspace : str
+        workspace : str, optional
             Default: "default".
         overwrite : bool
 
@@ -607,7 +610,7 @@ class Geoserver:
             return "Error create_datastore: {}".format(e)
 
     def create_shp_datastore(
-        self, path, store_name=None, workspace=None, file_extension="shp"
+        self, path: str, store_name: Optional[str] = None, workspace: Optional[str] = None, file_extension: str = "shp"
     ):
         """
         Create datastore for a shapefile.
@@ -616,9 +619,9 @@ class Geoserver:
         ----------
         path : str
             Path to the zipped shapefile (.shp).
-        store_name : str
+        store_name : str, optional
             Name of store to be created. If None, parses from the filename stem.
-        workspace: str
+        workspace: str, optional
             Name of workspace to be used. Default: "default".
         file_extension : str
 
@@ -670,8 +673,20 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def publish_featurestore(self, store_name, pg_table, workspace=None):
+    def publish_featurestore(self, store_name: str, pg_table: str, workspace: Optional[str] = None):
         """
+
+        Parameters
+        ----------
+        store_name : str
+        pg_table : str
+        workspace : str, optional
+
+        Returns
+        -------
+
+        Notes
+        -----
         Only user for postgis vector data
         input parameters: specify the name of the table in the postgis database to be published, specify the store,workspace name, and  the Geoserver user name, password and URL
         """
@@ -710,6 +725,22 @@ class Geoserver:
         geom_type="Geometry",
         workspace=None,
     ):
+        """
+
+        Parameters
+        ----------
+        name
+        store_name
+        sql
+        key_column
+        geom_name
+        geom_type
+        workspace
+
+        Returns
+        -------
+
+        """
         try:
             if workspace is None:
                 workspace = "default"
@@ -760,6 +791,20 @@ class Geoserver:
         self, path, name=None, workspace=None, sld_version="1.0.0", overwrite=False
     ):
         """
+
+        Parameters
+        ----------
+        path
+        name
+        workspace
+        sld_version
+        overwrite
+
+        Returns
+        -------
+
+        Notes
+        -----
         The name of the style file will be, sld_name:workspace
         This function will create the style file in a specified workspace.
         Inputs: path to the sld_file, workspace,
@@ -816,6 +861,17 @@ class Geoserver:
             return "Error: {}".format(e)
 
     def get_featuretypes(self, workspace=None, store_name=None):
+        """
+
+        Parameters
+        ----------
+        workspace
+        store_name
+
+        Returns
+        -------
+
+        """
         url = "{}/rest/workspaces/{}/datastores/{}/featuretypes.json".format(
             self.service_url, workspace, store_name
         )
@@ -827,6 +883,18 @@ class Geoserver:
         return features
 
     def get_feature_attribute(self, feature_type_name, workspace=None, store_name=None):
+        """
+
+        Parameters
+        ----------
+        feature_type_name
+        workspace
+        store_name
+
+        Returns
+        -------
+
+        """
         url = "{}/rest/workspaces/{}/datastores/{}/featuretypes/{}.json".format(
             self.service_url, workspace, store_name, feature_type_name
         )
@@ -862,6 +930,22 @@ class Geoserver:
         overwrite=False,
     ):
         """
+
+        Parameters
+        ----------
+        raster_path
+        style_name
+        workspace
+        color_ramp
+        cmap_type
+        number_of_classes
+        overwrite
+
+        Returns
+        -------
+
+        Notes
+        -----
         The name of the style file will be, rasterName:workspace
         This function will dynamically create the style file for raster.
         Inputs: name of file, workspace, cmap_type (two options: values, range), ncolors: determins the number of class, min for minimum value of the raster, max for the max value of raster
@@ -933,6 +1017,20 @@ class Geoserver:
         overwrite=False,
     ):
         """
+
+        Parameters
+        ----------
+        style_name
+        column_name
+        column_distinct_values
+        workspace
+        color_ramp
+        geom_type
+        outline_color
+        overwrite
+
+        Notes
+        -----
         Dynamically create the style for postgis geometry
         The data type must be point, line or polygon
         Inputs: column_name (based on which column style should be generated), workspace,
@@ -997,6 +1095,20 @@ class Geoserver:
         overwrite=False,
     ):
         """
+
+        Parameters
+        ----------
+        style_name
+        color
+        geom_type
+        workspace
+        overwrite
+
+        Returns
+        -------
+
+        Notes
+        -----
         Dynamically create the style for postgis geometry
         The geometry type must be point, line or polygon
         Inputs: style_name (name of the style file in geoserver), workspace, color (style color)
@@ -1051,13 +1163,27 @@ class Geoserver:
         style_name,
         column_name,
         column_distinct_values,
-        workspace=None,
-        color_ramp="tab20",
-        geom_type="polygon",
-        outline_color="#3579b1",
-        overwrite=False,
+        workspace: Optional[str] = None,
+        color_ramp: str = "tab20",
+        geom_type: str = "polygon",
+        outline_color: str = "#3579b1",
+        overwrite: bool = False,
     ):
         """
+
+        Parameters
+        ----------
+        style_name
+        column_name
+        column_distinct_values
+        workspace
+        color_ramp
+        geom_type
+        outline_color
+        overwrite
+
+        Notes
+        -----
         Dynamically create the style for postgis geometry
         The data type must be point, line or polygon
         Inputs: column_name (based on which column style should be generated), workspace,
@@ -1120,11 +1246,22 @@ class Geoserver:
             return "Error: {}".format(e)
 
     # def create_featurestyle()
-    def publish_style(self, layer_name, style_name, workspace, content_type="text/xml"):
-        """
-        publishing a raster file to geoserver
-        the coverage store will be created automatically as the same name as the raster layer name.
-        input parameters: the parameters connecting geoserver (user,password, url and workspace name),the path to the file and file_type indicating it is a geotiff, arcgrid or other raster type
+    def publish_style(self, layer_name: str, style_name: str, workspace: str, content_type: str = "text/xml"):
+        """Publish a raster file to geoserver.
+
+        Parameters
+        ----------
+        layer_name : str
+        style_name : str
+        workspace : str
+        content_type : str
+
+        Notes
+        -----
+        The coverage store will be created automatically as the same name as the raster layer name.
+        input parameters: the parameters connecting geoserver (user,password, url and workspace name),
+        the path to the file and file_type indicating it is a geotiff, arcgrid or other raster type.
+
         """
 
         try:
@@ -1149,7 +1286,17 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def delete_workspace(self, workspace):
+    def delete_workspace(self, workspace: str):
+        """
+
+        Parameters
+        ----------
+        workspace : str
+
+        Returns
+        -------
+
+        """
         try:
             payload = {"recurse": "true"}
             url = "{}/rest/workspaces/{}".format(self.service_url, workspace)
@@ -1164,7 +1311,15 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def delete_layer(self, layer_name, workspace=None):
+    def delete_layer(self, layer_name: str , workspace: Optional[str] = None):
+        """
+
+        Parameters
+        ----------
+        layer_name : str
+        workspace : str, optional
+
+        """
         try:
             payload = {"recurse": "true"}
             url = "{}/rest/workspaces/{}/layers/{}".format(
@@ -1185,7 +1340,15 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def delete_featurestore(self, featurestore_name, workspace):
+    def delete_featurestore(self, featurestore_name: str, workspace: Optional[str] = None):
+        """
+
+        Parameters
+        ----------
+        featurestore_name : str
+        workspace : str, optional
+
+        """
         try:
             payload = {"recurse": "true"}
             url = "{}/rest/workspaces/{}/datastores/{}".format(
@@ -1208,7 +1371,15 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def delete_coveragestore(self, coveragestore_name, workspace):
+    def delete_coveragestore(self, coveragestore_name: str, workspace: Optional[str] = None):
+        """
+
+        Parameters
+        ----------
+        coveragestore_name : str
+        workspace : str, optional
+
+        """
         try:
             payload = {"recurse": "true"}
             url = "{}/rest/workspaces/{}/coveragestores/{}".format(
@@ -1233,7 +1404,14 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def delete_style(self, style_name, workspace=None):
+    def delete_style(self, style_name, workspace: Optional[str] = None):
+        """
+
+        Parameters
+        ----------
+        style_name : str
+        workspace : str, optional
+        """
         try:
             payload = {"recurse": "true"}
             url = "{}/rest/workspaces/{}/styles/{}".format(

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -732,28 +732,25 @@ class Geoserver:
 
     def publish_featurestore_sqlview(
         self,
-        name,
-        store_name,
-        sql,
-        key_column=None,
-        geom_name="geom",
-        geom_type="Geometry",
-        workspace=None,
+        name : str,
+        store_name : str,
+        sql: str,
+        key_column: str,
+        geom_name: str = "geom",
+        geom_type: str = "Geometry",
+        workspace: Optional[str] = None,
     ):
         """
 
         Parameters
         ----------
-        name
-        store_name
-        sql
-        key_column
-        geom_name
-        geom_type
-        workspace
-
-        Returns
-        -------
+        name : str
+        store_name : str
+        sql : str
+        key_column : str
+        geom_name : str
+        geom_type : str
+        workspace : str, optional
 
         """
         try:
@@ -803,20 +800,17 @@ class Geoserver:
             return "Error:%s" % str(e)
 
     def upload_style(
-        self, path, name=None, workspace=None, sld_version="1.0.0", overwrite=False
+        self, path: str, name: Optional[str] = None, workspace: Optional[str] = None, sld_version: str ="1.0.0", overwrite: bool = False
     ):
         """
 
         Parameters
         ----------
-        path
-        name
-        workspace
-        sld_version
-        overwrite
-
-        Returns
-        -------
+        path : str
+        name : str, optional
+        workspace : str, optional
+        sld_version : str
+        overwrite : bool
 
         Notes
         -----
@@ -839,7 +833,7 @@ class Geoserver:
                 sld_content_type = "application/vnd.ogc.se+xml"
 
             if workspace is None:
-                workspace = "default"
+                # workspace = "default"
                 url = "{}/rest/styles".format(self.service_url)
 
             style_xml = "<style><name>{}</name><filename>{}</filename></style>".format(
@@ -875,16 +869,13 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def get_featuretypes(self, workspace=None, store_name=None):
+    def get_featuretypes(self, workspace: str = None, store_name: str = None):
         """
 
         Parameters
         ----------
-        workspace
-        store_name
-
-        Returns
-        -------
+        workspace : str
+        store_name : str
 
         """
         url = "{}/rest/workspaces/{}/datastores/{}/featuretypes.json".format(
@@ -897,17 +888,14 @@ class Geoserver:
 
         return features
 
-    def get_feature_attribute(self, feature_type_name, workspace=None, store_name=None):
+    def get_feature_attribute(self, feature_type_name: str, workspace: str, store_name: str):
         """
 
         Parameters
         ----------
-        feature_type_name
-        workspace
-        store_name
-
-        Returns
-        -------
+        feature_type_name : str
+        workspace : str
+        store_name : str
 
         """
         url = "{}/rest/workspaces/{}/datastores/{}/featuretypes/{}.json".format(
@@ -922,7 +910,15 @@ class Geoserver:
 
         return attribute
 
-    def get_featurestore(self, store_name, workspace):
+    def get_featurestore(self, store_name: str, workspace: str):
+        """
+
+        Parameters
+        ----------
+        store_name : str
+        workspace : str
+
+        """
         url = "{}/rest/workspaces/{}/datastores/{}".format(
             self.service_url, workspace, store_name
         )
@@ -936,28 +932,26 @@ class Geoserver:
 
     def create_coveragestyle(
         self,
-        raster_path,
-        style_name=None,
-        workspace=None,
-        color_ramp="RdYlGn_r",
-        cmap_type="ramp",
-        number_of_classes=5,
-        overwrite=False,
+        raster_path : str,
+        style_name: Optional[str]=None,
+        workspace: str = None,
+        color_ramp: str = "RdYlGn_r",
+        cmap_type: str = "ramp",
+        number_of_classes: int = 5,
+        overwrite: bool = False,
     ):
         """
 
         Parameters
         ----------
-        raster_path
-        style_name
-        workspace
-        color_ramp
-        cmap_type
-        number_of_classes
-        overwrite
-
-        Returns
-        -------
+        raster_path : str
+        style_name : str, optional
+        workspace : str
+        color_ramp : str
+        cmap_type : str
+            # TODO: This should be a set of the available options : {"ramp", "linear", ... }
+        number_of_classes : int
+        overwrite : bool
 
         Notes
         -----
@@ -1027,31 +1021,31 @@ class Geoserver:
 
     def create_catagorized_featurestyle(
         self,
-        style_name,
-        column_name,
+        style_name: str,
+        column_name: str,
         column_distinct_values,
-        workspace=None,
-        color_ramp="tab20",
-        geom_type="polygon",
-        outline_color="#3579b1",
-        overwrite=False,
+        workspace: str = None,
+        color_ramp: str = "tab20",
+        geom_type: str = "polygon",
+        outline_color: str = "#3579b1",
+        overwrite: bool = False,
     ):
-        """
+        """Dynamically create categorized style for postgis geometry,
 
         Parameters
         ----------
-        style_name
-        column_name
+        style_name : str
+        column_name : str
         column_distinct_values
-        workspace
-        color_ramp
-        geom_type
-        outline_color
-        overwrite
+        workspace : str
+        color_ramp : str
+        geom_type : str
+        outline_color : str
+        overwrite : bool
 
         Notes
         -----
-        Dynamically create the style for postgis geometry
+
         The data type must be point, line or polygon
         Inputs: column_name (based on which column style should be generated), workspace,
         color_or_ramp (color should be provided in hex code or the color ramp name, geom_type(point, line, polygon), outline_color(hex_color))
@@ -1108,28 +1102,27 @@ class Geoserver:
 
     def create_outline_featurestyle(
         self,
-        style_name,
-        color="#3579b1",
-        geom_type="polygon",
-        workspace=None,
-        overwrite=False,
+        style_name: str,
+        color: str = "#3579b1",
+        geom_type: str = "polygon",
+        workspace: Optional[str] = None,
+        overwrite: bool = False,
     ):
-        """
+        """Dynamically creates the outline style for postgis geometry
 
         Parameters
         ----------
-        style_name
-        color
-        geom_type
-        workspace
-        overwrite
+        style_name : str
+        color : str
+        geom_type : str
+        workspace : str, optional
+        overwrite : bool
 
         Returns
         -------
 
         Notes
         -----
-        Dynamically create the style for postgis geometry
         The geometry type must be point, line or polygon
         Inputs: style_name (name of the style file in geoserver), workspace, color (style color)
         """
@@ -1180,31 +1173,28 @@ class Geoserver:
 
     def create_classified_featurestyle(
         self,
-        style_name,
-        column_name,
+        style_name: str,
+        column_name: str,
         column_distinct_values,
         workspace: Optional[str] = None,
         color_ramp: str = "tab20",
-        geom_type: str = "polygon",
-        outline_color: str = "#3579b1",
+        # geom_type: str = "polygon",
+        # outline_color: str = "#3579b1",
         overwrite: bool = False,
     ):
-        """
+        """Dynamically creates the classified style for postgis geometries.
 
         Parameters
         ----------
-        style_name
-        column_name
+        style_name : str
+        column_name : str
         column_distinct_values
-        workspace
-        color_ramp
-        geom_type
-        outline_color
-        overwrite
+        workspace : str, optional
+        color_ramp : str
+        overwrite : bool
 
         Notes
         -----
-        Dynamically create the style for postgis geometry
         The data type must be point, line or polygon
         Inputs: column_name (based on which column style should be generated), workspace,
         color_or_ramp (color should be provided in hex code or the color ramp name, geom_type(point, line, polygon), outline_color(hex_color))
@@ -1265,7 +1255,6 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    # def create_featurestyle()
     def publish_style(
         self,
         layer_name: str,
@@ -1318,9 +1307,6 @@ class Geoserver:
         Parameters
         ----------
         workspace : str
-
-        Returns
-        -------
 
         """
         try:
@@ -1434,7 +1420,7 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def delete_style(self, style_name, workspace: Optional[str] = None):
+    def delete_style(self, style_name: str, workspace: Optional[str] = None):
         """
 
         Parameters

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -732,8 +732,8 @@ class Geoserver:
 
     def publish_featurestore_sqlview(
         self,
-        name : str,
-        store_name : str,
+        name: str,
+        store_name: str,
         sql: str,
         key_column: str,
         geom_name: str = "geom",
@@ -800,7 +800,12 @@ class Geoserver:
             return "Error:%s" % str(e)
 
     def upload_style(
-        self, path: str, name: Optional[str] = None, workspace: Optional[str] = None, sld_version: str ="1.0.0", overwrite: bool = False
+        self,
+        path: str,
+        name: Optional[str] = None,
+        workspace: Optional[str] = None,
+        sld_version: str = "1.0.0",
+        overwrite: bool = False,
     ):
         """
 
@@ -888,7 +893,9 @@ class Geoserver:
 
         return features
 
-    def get_feature_attribute(self, feature_type_name: str, workspace: str, store_name: str):
+    def get_feature_attribute(
+        self, feature_type_name: str, workspace: str, store_name: str
+    ):
         """
 
         Parameters
@@ -932,8 +939,8 @@ class Geoserver:
 
     def create_coveragestyle(
         self,
-        raster_path : str,
-        style_name: Optional[str]=None,
+        raster_path: str,
+        style_name: Optional[str] = None,
         workspace: str = None,
         color_ramp: str = "RdYlGn_r",
         cmap_type: str = "ramp",

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -32,6 +32,16 @@ class FileReader:
 
 
 class Geoserver:
+    """
+    Attributes
+    ----------
+    service_url : str
+        The URL for the GeoServer instance.
+    username : str
+        Login name for session.
+    password: str
+        Password for session.
+    """
     def __init__(
         self,
         service_url="http://localhost:8080/geoserver",
@@ -44,7 +54,7 @@ class Geoserver:
 
     def get_manifest(self):
         """
-        It returns the manifest of the geoserver
+        Returns the manifest of the geoserver.
         """
         try:
             url = "{}/rest/about/manifest.json".format(self.service_url)
@@ -52,11 +62,11 @@ class Geoserver:
             return r.json()
 
         except Exception as e:
-            return ("get_manifest error: ", e)
+            return "get_manifest error: ", e
 
     def get_version(self):
         """
-        It returns the version of the geoserver
+        Returns the version of the geoserver.
         """
         try:
             url = "{}/rest/about/version.json".format(self.service_url)
@@ -64,11 +74,11 @@ class Geoserver:
             return r.json()
 
         except Exception as e:
-            return ("get_version error: ", e)
+            return "get_version error: ", e
 
     def get_status(self):
         """
-        It returns the status of the geoserver
+        Returns the status of the geoserver.
         """
         try:
             url = "{}/rest/about/status.json".format(self.service_url)
@@ -76,7 +86,7 @@ class Geoserver:
             return r.json()
 
         except Exception as e:
-            return ("get_status error: ", e)
+            return "get_status error: ", e
 
     def get_system_status(self):
         """
@@ -88,11 +98,14 @@ class Geoserver:
             return r.json()
 
         except Exception as e:
-            return ("get_system_status error: ", e)
+            return "get_system_status error: ", e
 
     def reload(self):
         """
-        Reloads the GeoServer catalog and configuration from disk. This operation is used in cases where an external tool has modified the on-disk configuration. This operation will also force GeoServer to drop any internal caches and reconnect to all data stores.
+        Reloads the GeoServer catalog and configuration from disk.
+
+        This operation is used in cases where an external tool has modified the on-disk configuration.
+        This operation will also force GeoServer to drop any internal caches and reconnect to all data stores.
         curl -X POST http://localhost:8080/geoserver/rest/reload -H  "accept: application/json" -H  "content-type: application/json"
         """
         try:
@@ -105,7 +118,10 @@ class Geoserver:
 
     def reset(self):
         """
-        Resets all store, raster, and schema caches. This operation is used to force GeoServer to drop all caches and store connections and reconnect to each of them the next time they are needed by a request. This is useful in case the stores themselves cache some information about the data structures they manage that may have changed in the meantime.
+        Resets all store, raster, and schema caches. This operation is used to force GeoServer to drop all caches and
+        store connections and reconnect to each of them the next time they are needed by a request. This is useful in
+        case the stores themselves cache some information about the data structures they manage that may have changed
+        in the meantime.
         curl -X POST http://localhost:8080/geoserver/rest/reset -H  "accept: application/json" -H  "content-type: application/json"
         """
         try:
@@ -116,9 +132,10 @@ class Geoserver:
         except Exception as e:
             return "reload error: {}".format(e)
 
-    def get_datastore(self, store_name, workspace=None):
+    def get_datastore(self, store_name: str, workspace: str = None):
         """
-        data store in given workspace
+        Return the data store in a given workspace.
+
         If workspace is not provided, it will take the default workspace
         curl -X GET http://localhost:8080/geoserver/rest/workspaces/demo/datastores -H  "accept: application/xml" -H  "content-type: application/json"
         """
@@ -136,9 +153,10 @@ class Geoserver:
         except Exception as e:
             return "get_datastores error: {}".format(e)
 
-    def get_datastores(self, workspace=None):
+    def get_datastores(self, workspace: str = None):
         """
-        List all data stores in workspace ws.
+        List all data stores in a workspace.
+
         If workspace is not provided, it will listout all the datastores inside default workspace
         curl -X GET http://localhost:8080/geoserver/rest/workspaces/demo/datastores -H  "accept: application/xml" -H  "content-type: application/json"
         """
@@ -155,9 +173,9 @@ class Geoserver:
         except Exception as e:
             return "get_datastores error: {}".format(e)
 
-    def get_coveragestore(self, coveragestore_name, workspace=None):
+    def get_coveragestore(self, coveragestore_name: str, workspace: str = None):
         """
-        It returns the store name if exist
+        Returns the store name if it exists.
         """
         try:
             payload = {"recurse": "true"}
@@ -174,9 +192,9 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def get_coveragestores(self, workspace=None):
+    def get_coveragestores(self, workspace: str = None):
         """
-        Get all the coveragestores inside specific workspace
+        Returns all the coveragestores inside a specific workspace.
         """
         try:
             if workspace is None:
@@ -191,9 +209,9 @@ class Geoserver:
         except Exception as e:
             return "get_coveragestores error: {}".format(e)
 
-    def get_layer(self, layer_name, workspace=None):
+    def get_layer(self, layer_name: str, workspace: str = None):
         """
-        Get the layer by layer name
+        Returns the layer by layer name.
         """
         try:
             url = "{}/rest/layers/{}".format(self.service_url, layer_name)
@@ -208,7 +226,7 @@ class Geoserver:
         except Exception as e:
             return "get_layer error: {}".format(e)
 
-    def get_layers(self, workspace=None):
+    def get_layers(self, workspace: str = None):
         """
         Get all the layers from geoserver
         If workspace is None, it will listout all the layers from geoserver
@@ -224,10 +242,13 @@ class Geoserver:
         except Exception as e:
             return "get_layers error: {}".format(e)
 
-    def get_layergroups(self, workspace=None):
+    def get_layergroups(self, workspace: str = None):
         """
-        Get all the layer groups from geoserver
-        If workspace is None, it will listout all the layer groups from geoserver
+        Returns all the layer groups from geoserver.
+
+        Notes
+        -----
+        If workspace is None, it will list all the layer groups from geoserver.
         """
         try:
             url = "{}/rest/layergroups".format(self.service_url)
@@ -242,9 +263,9 @@ class Geoserver:
         except Exception as e:
             return "get_layers error: {}".format(e)
 
-    def get_layergroup(self, layer_name, workspace=None):
+    def get_layergroup(self, layer_name: str, workspace: str = None):
         """
-        Get the layer group by layer group name
+        Returns the layer group by layer group name.
         """
         try:
             url = "{}/rest/layergroups/{}".format(self.service_url, layer_name)
@@ -261,7 +282,7 @@ class Geoserver:
 
     def get_style(self, style_name, workspace=None):
         """
-        Get the style by style name
+        Returns the style by style name.
         """
         try:
             url = "{}/rest/styles/{}.json".format(self.service_url, style_name)
@@ -278,7 +299,7 @@ class Geoserver:
 
     def get_styles(self, workspace=None):
         """
-        Get all the styles from geoserver
+        Returns all loaded styles from geoserver.
         """
         try:
             url = "{}/rest/styles.json".format(self.service_url)
@@ -295,7 +316,7 @@ class Geoserver:
 
     def get_default_workspace(self):
         """
-        Get the default workspace
+        Returns the default workspace.
         """
         try:
             url = "{}/rest/workspaces/default".format(self.service_url)
@@ -307,7 +328,7 @@ class Geoserver:
 
     def get_workspaces(self):
         """
-        Get all the workspaces
+        Returns all the workspaces.
         """
         try:
             url = "{}/rest/workspaces".format(self.service_url)
@@ -317,9 +338,9 @@ class Geoserver:
         except Exception as e:
             return "get_workspaces error: {}".format(e)
 
-    def set_default_workspace(self, workspace):
+    def set_default_workspace(self, workspace: str):
         """
-        Set the default workspace
+        Set the default workspace.
         """
         try:
             url = "{}/rest/workspaces/default".format(self.service_url)
@@ -340,9 +361,11 @@ class Geoserver:
         except Exception as e:
             return "reload error: {}".format(e)
 
-    def create_workspace(self, workspace):
+    def create_workspace(self, workspace: str):
         """
-        Create a new workspace in geoserver, geoserver workspace url will be same as name of the workspace
+        Create a new workspace in geoserver.
+
+        The geoserver workspace url will be same as the name of the workspace.
         """
         try:
             url = "{}/rest/workspaces".format(self.service_url)
@@ -364,9 +387,10 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def get_workspace(self, workspace):
+    def get_workspace(self, workspace: str):
         """
-        get name  workspace if exist
+        Get workspace name if it exists.
+
         Example: curl -v -u admin:admin -XGET -H "Accept: text/xml"  http://localhost:8080/geoserver/rest/workspaces/acme.xml
         """
         try:
@@ -384,15 +408,27 @@ class Geoserver:
     def create_coveragestore(
         self,
         path,
-        workspace=None,
-        lyr_name=None,
-        file_type="GeoTIFF",
-        content_type="image/tiff",
-        overwrite=False,
+        workspace: str = None,
+        layer_name: str = None,
+        file_type: str = "GeoTIFF",
+        content_type: str = "image/tiff",
+        overwrite: bool = False,
     ):
         """
-        created the coveragestore, data will uploaded to the server
-        the name parameter will be the name of coveragestore (coveragestore name will be assigned as the file name incase of not providing name parameter)
+        Creates the coveragestore; Data will uploaded to the server.
+
+        Parameters
+        ----------
+        path : str
+        workspace : str
+        layer_name : str
+            The name of coveragestore. If not provided, parsed from the file name.
+        file_type : str
+        content_type : str
+        overwrite : bool
+
+        Notes
+        -----
         the path to the file and file_type indicating it is a geotiff, arcgrid or other raster type
         """
 
@@ -402,8 +438,8 @@ class Geoserver:
 
             c = pycurl.Curl()
 
-            if lyr_name:
-                file_name = lyr_name
+            if layer_name:
+                file_name = layer_name
 
             else:
                 file_name = os.path.basename(path)
@@ -437,20 +473,34 @@ class Geoserver:
 
     def create_featurestore(
         self,
-        store_name,
-        workspace=None,
-        db="postgres",
-        host="localhost",
-        port=5432,
-        schema="public",
-        pg_user="postgres",
-        pg_password="admin",
-        overwrite=False,
+        store_name: str,
+        workspace: str = None,
+        db: str = "postgres",
+        host: str = "localhost",
+        port: int = 5432,
+        schema: str = "public",
+        pg_user: str = "postgres",
+        pg_password: str = "admin",
+        overwrite: bool = False,
     ):
         """
-        Postgis store for connecting postgres with geoserver
-        After creating feature store, you need to publish it
-        Input parameters:specify the store name you want to be created, the postgis database parameters including host, port, database name, schema, user and password,
+        Create PostGIS store for connecting postgres with geoserver.
+
+        Parameters
+        ----------
+        store_name : str
+        workspace : str
+        db : str
+        host : str
+        port : int
+        schema : str
+        pg_user : str
+        pg_password : str
+        overwrite : bool
+
+        Notes
+        -----
+        After creating feature store, you need to publish it.
         """
         try:
             if workspace is None:
@@ -494,18 +544,25 @@ class Geoserver:
         except Exception as e:
             return "Error:%s" % str(e)
 
-    def create_datastore(self, name, path, workspace=None, overwrite=False):
+    def create_datastore(self, name: str, path: str, workspace: str = None, overwrite: bool = False):
         """
-        The path referes as path to,
-            1. shapefile (.shp) file or
-            2. GeoPackage (.gpkg) file or
-            3. WFS url (http://localhost:8080/geoserver/wfs?request=GetCapabilities) or
-            4. directory containing shapefiles.
+        Create a datastore within the GeoServer.
 
+        Parameters
+        ----------
+        name : str
+            Name of datastore to be created.
+            After creating the datastore, you need to publish it by using publish_featurestore function.
+        path : str
+            Path to shapefile (.shp) file, GeoPackage (.gpkg) file, WFS url
+            (e.g. http://localhost:8080/geoserver/wfs?request=GetCapabilities) or directory containing shapefiles.
+        workspace : str
+            Default: "default".
+        overwrite : bool
+
+        Notes
+        -----
         If you have PostGIS datastore, please use create_featurestore function
-
-        The name referes as name of the datastore
-        After creating the datastore, you need to publish it by using publish_featurestore function
         """
         if workspace is None:
             workspace = "default"
@@ -524,7 +581,6 @@ class Geoserver:
         headers = {"content-type": "text/xml"}
 
         try:
-            r = None
             if overwrite:
                 url = "{}/rest/workspaces/{}/datastores/{}".format(
                     self.service_url, workspace, name
@@ -551,11 +607,23 @@ class Geoserver:
             return "Error create_datastore: {}".format(e)
 
     def create_shp_datastore(
-        self, path, store_name=None, workspace=None, file_format="shp"
+        self, path, store_name=None, workspace=None, file_extension="shp"
     ):
         """
-        Create the datastore for shapefile
-        Path refers to the path to the zipped shapefile
+        Create datastore for a shapefile.
+
+        Parameters
+        ----------
+        path : str
+            Path to the zipped shapefile (.shp).
+        store_name : str
+            Name of store to be created. If None, parses from the filename stem.
+        workspace: str
+            Name of workspace to be used. Default: "default".
+        file_extension : str
+
+        Notes
+        -----
         The layer name will be assigned according to the shp name
         """
         try:
@@ -580,7 +648,7 @@ class Geoserver:
                 path = prepare_zip_file(store_name, path)
 
             url = "{0}/rest/workspaces/{1}/datastores/{2}/file.{3}?filename={2}&update=overwrite".format(
-                self.service_url, workspace, store_name, file_format
+                self.service_url, workspace, store_name, file_extension
             )
 
             with open(path, "rb") as f:
@@ -614,6 +682,7 @@ class Geoserver:
             c = pycurl.Curl()
             layer_xml = "<featureType><name>{}</name></featureType>".format(pg_table)
             c.setopt(pycurl.USERPWD, self.username + ":" + self.password)
+
             # connecting with the specified store in geoserver
             c.setopt(
                 c.URL,

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -45,6 +45,7 @@ class Geoserver:
     password: str
         Password for session.
     """
+
     def __init__(
         self,
         service_url="http://localhost:8080/geoserver",
@@ -176,7 +177,9 @@ class Geoserver:
         except Exception as e:
             return "get_datastores error: {}".format(e)
 
-    def get_coveragestore(self, coveragestore_name: str, workspace: Optional[str] = None):
+    def get_coveragestore(
+        self, coveragestore_name: str, workspace: Optional[str] = None
+    ):
         """
         Returns the store name if it exists.
         """
@@ -547,7 +550,13 @@ class Geoserver:
         except Exception as e:
             return "Error:%s" % str(e)
 
-    def create_datastore(self, name: str, path: str, workspace: Optional[str] = None, overwrite: bool = False):
+    def create_datastore(
+        self,
+        name: str,
+        path: str,
+        workspace: Optional[str] = None,
+        overwrite: bool = False,
+    ):
         """
         Create a datastore within the GeoServer.
 
@@ -610,7 +619,11 @@ class Geoserver:
             return "Error create_datastore: {}".format(e)
 
     def create_shp_datastore(
-        self, path: str, store_name: Optional[str] = None, workspace: Optional[str] = None, file_extension: str = "shp"
+        self,
+        path: str,
+        store_name: Optional[str] = None,
+        workspace: Optional[str] = None,
+        file_extension: str = "shp",
     ):
         """
         Create datastore for a shapefile.
@@ -673,7 +686,9 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def publish_featurestore(self, store_name: str, pg_table: str, workspace: Optional[str] = None):
+    def publish_featurestore(
+        self, store_name: str, pg_table: str, workspace: Optional[str] = None
+    ):
         """
 
         Parameters
@@ -952,12 +967,17 @@ class Geoserver:
         """
         try:
             raster = raster_value(raster_path)
-            min = raster["min"]
-            max = raster["max"]
+            min_value = raster["min"]
+            max_value = raster["max"]
             if style_name is None:
                 style_name = raster["file_name"]
             coverage_style_xml(
-                color_ramp, style_name, cmap_type, min, max, number_of_classes
+                color_ramp,
+                style_name,
+                cmap_type,
+                min_value,
+                max_value,
+                number_of_classes,
             )
             style_xml = "<style><name>{}</name><filename>{}</filename></style>".format(
                 style_name, style_name + ".sld"
@@ -1246,7 +1266,13 @@ class Geoserver:
             return "Error: {}".format(e)
 
     # def create_featurestyle()
-    def publish_style(self, layer_name: str, style_name: str, workspace: str, content_type: str = "text/xml"):
+    def publish_style(
+        self,
+        layer_name: str,
+        style_name: str,
+        workspace: str,
+        content_type: str = "text/xml",
+    ):
         """Publish a raster file to geoserver.
 
         Parameters
@@ -1311,7 +1337,7 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def delete_layer(self, layer_name: str , workspace: Optional[str] = None):
+    def delete_layer(self, layer_name: str, workspace: Optional[str] = None):
         """
 
         Parameters
@@ -1340,7 +1366,9 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def delete_featurestore(self, featurestore_name: str, workspace: Optional[str] = None):
+    def delete_featurestore(
+        self, featurestore_name: str, workspace: Optional[str] = None
+    ):
         """
 
         Parameters
@@ -1371,7 +1399,9 @@ class Geoserver:
         except Exception as e:
             return "Error: {}".format(e)
 
-    def delete_coveragestore(self, coveragestore_name: str, workspace: Optional[str] = None):
+    def delete_coveragestore(
+        self, coveragestore_name: str, workspace: Optional[str] = None
+    ):
         """
 
         Parameters

--- a/geo/Postgres.py
+++ b/geo/Postgres.py
@@ -2,6 +2,20 @@ from psycopg2 import sql, connect
 
 
 class Db:
+    """
+    Attributes
+    ----------
+    dbname : str, optional
+        The name of the postgresql database.
+    user : str
+        Login name for session.
+    password: str
+        Password for session.
+    host : str
+        hostname of postgresql database
+    port : int
+    """
+
     def __init__(
         self,
         dbname=None,
@@ -29,16 +43,17 @@ class Db:
             self.conn = None
 
     # Execute sql query
-    def execute_sql(self, cursor, sql):
+    @staticmethod
+    def execute_sql(cursor, sql_query):
         try:
-            cursor.execute(sql)
+            cursor.execute(sql_query)
 
         except Exception as err:
             print("ERROR: ", err)
 
     # get the columns names inside database
     def get_columns_names(self, table):
-        columns = []
+        columns = list()
         with self.conn.cursor() as col_cursor:
             col_names_str = "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = '{}';".format(table)
             sql_object = sql.SQL(col_names_str).format(sql.Identifier(table))
@@ -75,7 +90,7 @@ class Db:
             )
 
             try:
-                col_cursor.execute(sql_object, (column))
+                col_cursor.execute(sql_object, column)
                 values_name = col_cursor.fetchall()
                 for tup in values_name:
                     values += [tup[0]]
@@ -86,14 +101,14 @@ class Db:
         return values
 
     # create the schema based on the given name
-    def create_schema(self, name, dbname="postgres"):
+    def create_schema(self, name,):  # dbname="postgres"
         n = name.split(" ")
         if len(n) > 0:
             name = name.replace(" ", "_")
 
         with self.conn.cursor() as cursor:
-            sql = f"""CREATE SCHEMA IF NOT EXISTS {name}"""
-            self.execute_sql(cursor, sql)
+            sql_query = f"""CREATE SCHEMA IF NOT EXISTS {name}"""
+            self.execute_sql(cursor, sql_query)
             self.conn.commit()
             print("Schema create successfully")
 
@@ -101,41 +116,41 @@ class Db:
     def create_column(self, col_name, table, schema, col_datatype="varchar"):
 
         with self.conn.cursor() as cursor:
-            sql = """ALTER TABLE "{3}"."{0}" ADD IF NOT EXISTS "{1}" {2}""".format(
+            sql_query = """ALTER TABLE "{3}"."{0}" ADD IF NOT EXISTS "{1}" {2}""".format(
                 table, col_name, col_datatype, schema
             )
-            self.execute_sql(cursor, sql)
+            self.execute_sql(cursor, sql_query)
             self.conn.commit()
             print("create column successful")
 
     # update column
     def update_column(self, column, value, table, schema, where_col, where_val):
         with self.conn.cursor() as cursor:
-            sql = """
+            sql_query = """
                 UPDATE "{}"."{}" SET "{}"='{}' WHERE "{}"='{}'
                 """.format(
                 schema, table, column, value, where_col, where_val
             )
-            self.execute_sql(cursor, sql)
+            self.execute_sql(cursor, sql_query)
             self.conn.commit()
             print("update table successful")
 
     # delete table
     def delete_table(self, table_name, schema):
         with self.conn.cursor() as cursor:
-            sql = """DROP TABLE IF EXISTS "{}"."{}" CASCADE;""".format(
+            sql_query = """DROP TABLE IF EXISTS "{}"."{}" CASCADE;""".format(
                 schema, table_name
             )
-            self.execute_sql(cursor, sql)
+            self.execute_sql(cursor, sql_query)
             self.conn.commit()
             print("{} table dropped successfully.".format(table_name))
 
     # Delete values
     def delete_values(self, table_name, schema, condition):
         with self.conn.cursor() as cursor:
-            sql = """DELETE FROM "{}"."{}" WHERE {}""".format(
+            sql_query = """DELETE FROM "{}"."{}" WHERE {}""".format(
                 schema, table_name, condition
             )
-            self.execute_sql(cursor, sql)
+            self.execute_sql(cursor, sql_query)
             self.conn.commit()
             print("Values dropped successfully.")

--- a/geo/Postgres.py
+++ b/geo/Postgres.py
@@ -1,4 +1,6 @@
-from psycopg2 import sql, connect
+from typing import Union
+
+from psycopg2 import connect, sql
 
 
 class Db:
@@ -44,7 +46,7 @@ class Db:
 
     # Execute sql query
     @staticmethod
-    def execute_sql(cursor, sql_query):
+    def execute_sql(cursor, sql_query: str):
         try:
             cursor.execute(sql_query)
 
@@ -52,10 +54,12 @@ class Db:
             print("ERROR: ", err)
 
     # get the columns names inside database
-    def get_columns_names(self, table):
+    def get_columns_names(self, table: str):
         columns = list()
         with self.conn.cursor() as col_cursor:
-            col_names_str = "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = '{}';".format(table)
+            col_names_str = "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = '{}';".format(
+                table
+            )
             sql_object = sql.SQL(col_names_str).format(sql.Identifier(table))
             try:
                 col_cursor.execute(sql_object)
@@ -69,7 +73,9 @@ class Db:
         return columns
 
     # get all the values from specific column
-    def get_all_values(self, column, table, schema, distinct=True):
+    def get_all_values(
+        self, column: str, table: str, schema: str, distinct: bool = True
+    ):
         values = []
         with self.conn.cursor() as col_cursor:
             if distinct:
@@ -101,7 +107,7 @@ class Db:
         return values
 
     # create the schema based on the given name
-    def create_schema(self, name,):  # dbname="postgres"
+    def create_schema(self, name: str):  # dbname="postgres"
         n = name.split(" ")
         if len(n) > 0:
             name = name.replace(" ", "_")
@@ -113,18 +119,30 @@ class Db:
             print("Schema create successfully")
 
     # create new column in table
-    def create_column(self, col_name, table, schema, col_datatype="varchar"):
+    def create_column(
+        self, col_name: str, table: str, schema: str, col_datatype: str = "varchar"
+    ):
 
         with self.conn.cursor() as cursor:
-            sql_query = """ALTER TABLE "{3}"."{0}" ADD IF NOT EXISTS "{1}" {2}""".format(
-                table, col_name, col_datatype, schema
+            sql_query = (
+                """ALTER TABLE "{3}"."{0}" ADD IF NOT EXISTS "{1}" {2}""".format(
+                    table, col_name, col_datatype, schema
+                )
             )
             self.execute_sql(cursor, sql_query)
             self.conn.commit()
             print("create column successful")
 
     # update column
-    def update_column(self, column, value, table, schema, where_col, where_val):
+    def update_column(
+        self,
+        column: str,
+        value: Union[str, float, int],
+        table: str,
+        schema: str,
+        where_col: str,
+        where_val: str,
+    ):
         with self.conn.cursor() as cursor:
             sql_query = """
                 UPDATE "{}"."{}" SET "{}"='{}' WHERE "{}"='{}'
@@ -136,7 +154,7 @@ class Db:
             print("update table successful")
 
     # delete table
-    def delete_table(self, table_name, schema):
+    def delete_table(self, table_name: str, schema: str):
         with self.conn.cursor() as cursor:
             sql_query = """DROP TABLE IF EXISTS "{}"."{}" CASCADE;""".format(
                 schema, table_name
@@ -146,7 +164,7 @@ class Db:
             print("{} table dropped successfully.".format(table_name))
 
     # Delete values
-    def delete_values(self, table_name, schema, condition):
+    def delete_values(self, table_name: str, schema: str, condition: str):
         with self.conn.cursor() as cursor:
             sql_query = """DELETE FROM "{}"."{}" WHERE {}""".format(
                 schema, table_name, condition

--- a/geo/Style.py
+++ b/geo/Style.py
@@ -1,5 +1,3 @@
-import pycurl
-import os
 import seaborn as sns
 from matplotlib.colors import rgb2hex
 

--- a/geo/Style.py
+++ b/geo/Style.py
@@ -1,25 +1,46 @@
+from typing import Dict, Iterable, List, Union
+
 import seaborn as sns
 from matplotlib.colors import rgb2hex
 
 
-def coverage_style_colormapentry(color_ramp, min, max, number_of_classes):
+def coverage_style_colormapentry(
+    color_ramp: Union[List, Dict, Iterable],
+    min_value: float,
+    max_value: float,
+    number_of_classes: int = None,
+):
     """
+
+    Parameters
+    ----------
+    color_ramp
+    min_value
+    max_value
+    number_of_classes
+
+    Returns
+    -------
+
+    Notes
+    -----
     This is the core function for controlling the layers styles
     The color_ramp can be list or dict or touple or str
     min, max will be dynamically calculated value from raster
     number_of_classes will be available in map legend
     """
     style_append = ""
-    if type(color_ramp) is list:
-        N = len(color_ramp)
+    n = len(color_ramp)
 
-        if N != number_of_classes:
-            number_of_classes = N
+    if isinstance(color_ramp, list):
 
-        interval = (max - min) / (number_of_classes - 1)
+        if n != number_of_classes:
+            number_of_classes = n
+
+        interval = (max_value - min_value) / (number_of_classes - 1)
 
         for i, color in enumerate(color_ramp):
-            value = min + interval * i
+            value = min_value + interval * i
             value = round(value, 1)
 
             style_append += (
@@ -28,16 +49,15 @@ def coverage_style_colormapentry(color_ramp, min, max, number_of_classes):
                 )
             )
 
-    elif type(color_ramp) is dict:
-        N = len(color_ramp)
+    elif isinstance(color_ramp, dict):
 
-        if N != number_of_classes:
-            number_of_classes = N
+        if n != number_of_classes:
+            number_of_classes = n
 
-        interval = (max - min) / (number_of_classes - 1)
+        interval = (max_value - min_value) / (number_of_classes - 1)
 
-        for name, color, i in zip(color_ramp.keys(), color_ramp.values(), range(N)):
-            value = min + interval * i
+        for name, color, i in zip(color_ramp.keys(), color_ramp.values(), range(n)):
+            value = min_value + interval * i
 
             style_append += (
                 '<sld:ColorMapEntry color="{}" label=" {}" quantity="{}"/>'.format(
@@ -47,9 +67,8 @@ def coverage_style_colormapentry(color_ramp, min, max, number_of_classes):
 
     else:
         for i, color in enumerate(color_ramp):
-            N = number_of_classes
-            interval = (max - min) / (number_of_classes - 1)
-            value = min + interval * i
+            interval = (max_value - min_value) / (number_of_classes - 1)
+            value = min_value + interval * i
 
             style_append += (
                 '<sld:ColorMapEntry color="{}" label="{}" quantity="{}"/>'.format(
@@ -60,8 +79,10 @@ def coverage_style_colormapentry(color_ramp, min, max, number_of_classes):
     return style_append
 
 
-def coverage_style_xml(color_ramp, style_name, cmap_type, min, max, number_of_classes):
-    min_max_difference = max - min
+def coverage_style_xml(
+    color_ramp, style_name, cmap_type, min_value, max_value, number_of_classes
+):
+    min_max_difference = max_value - min_value
     style_append = ""
     interval = min_max_difference / (number_of_classes - 1)  # noqa
 
@@ -71,7 +92,7 @@ def coverage_style_xml(color_ramp, style_name, cmap_type, min, max, number_of_cl
         color_ramp = [rgb2hex(i) for i in palette]
 
     style_append += coverage_style_colormapentry(
-        color_ramp, min, max, number_of_classes
+        color_ramp, min_value, max_value, number_of_classes
     )
 
     style = """
@@ -179,9 +200,14 @@ def outline_only_xml(color, geom_type="polygon"):
         f.write(style)
 
 
-def catagorize_xml(column_name, values, color_ramp, geom_type="polygon"):
-    N = len(values)
-    palette = sns.color_palette(color_ramp, int(N))
+def catagorize_xml(
+    column_name: str,
+    values: List[float],
+    color_ramp: str = None,
+    geom_type: str = "polygon",
+):
+    n = len(values)
+    palette = sns.color_palette(color_ramp, int(n))
     palette_hex = [rgb2hex(i) for i in palette]
     rule = ""
     for value, color in zip(values, palette_hex):
@@ -283,13 +309,19 @@ def catagorize_xml(column_name, values, color_ramp, geom_type="polygon"):
         f.write(style)
 
 
-def classified_xml(style_name, column_name, values, color_ramp, geom_type="polygon"):
+def classified_xml(
+    style_name: str,
+    column_name: str,
+    values: List[float],
+    color_ramp: str = None,
+    geom_type: str = "polygon",
+):
     max_value = max(values)
     min_value = min(values)
     diff = max_value - min_value
-    N = 5
+    n = 5
     interval = diff / 5
-    palette = sns.color_palette(color_ramp, int(N))
+    palette = sns.color_palette(color_ramp, int(n))
     palette_hex = [rgb2hex(i) for i in palette]
     # interval = N/4
     # color_values = [{value: color} for value, color in zip(values, palette_hex)]

--- a/geo/__init__.py
+++ b/geo/__init__.py
@@ -1,2 +1,1 @@
-from . import Style
-from . import Calculation_gdal
+from . import Calculation_gdal, Style

--- a/geo/supports.py
+++ b/geo/supports.py
@@ -1,10 +1,12 @@
 from tempfile import mkstemp
 from zipfile import ZipFile
 import os
+from typing import Dict
 
 
-def prepare_zip_file(name, data):
-    """
+def prepare_zip_file(name: str, data: Dict):
+    """Creates a zip file from
+
     GeoServer's REST API uses ZIP archives as containers for file formats such
     as Shapefile and WorldImage which include several 'boxcar' files alongside
     the main data.  In such archives, GeoServer assumes that all of the relevant
@@ -13,6 +15,15 @@ def prepare_zip_file(name, data):
     these expectations, based on a basename, and a dict of extensions to paths or
     file-like objects. The client code is responsible for deleting the zip
     archive when it's done.
+
+    Parameters
+    ----------
+    name : name of files
+    data : dict
+
+    Returns
+    -------
+    str
     """
     fd, path = mkstemp()
     zip_file = ZipFile(path, "w", allowZip64=True)

--- a/geo/supports.py
+++ b/geo/supports.py
@@ -1,7 +1,7 @@
-from tempfile import mkstemp
-from zipfile import ZipFile
 import os
+from tempfile import mkstemp
 from typing import Dict
+from zipfile import ZipFile
 
 
 def prepare_zip_file(name: str, data: Dict) -> str:

--- a/geo/supports.py
+++ b/geo/supports.py
@@ -4,7 +4,7 @@ import os
 from typing import Dict
 
 
-def prepare_zip_file(name: str, data: Dict):
+def prepare_zip_file(name: str, data: Dict) -> str:
     """Creates a zip file from
 
     GeoServer's REST API uses ZIP archives as containers for file formats such

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 seaborn
 gdal
 psycopg2
+matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,9 @@ exclude =
 	src,
 	.eggs,
 
+[isort]
+profile = black
+
 [tool:pytest]
 norecursedirs = src .git bin conda-recipe joss
 python_files = test_*.py

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from setuptools import setup
 import os
+
+from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,8 @@
+from geo.Geoserver import Geoserver
+import os
+
+GEO_URL = os.getenv("GEO_URL", "http://localhost:8080/geoserver")
+
+geo = Geoserver(
+    GEO_URL, username="admin", password="geoserver"
+)

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,6 +3,4 @@ import os
 
 GEO_URL = os.getenv("GEO_URL", "http://localhost:8080/geoserver")
 
-geo = Geoserver(
-    GEO_URL, username="admin", password="geoserver"
-)
+geo = Geoserver(GEO_URL, username="admin", password="geoserver")

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,5 +1,6 @@
-from geo.Geoserver import Geoserver
 import os
+
+from geo.Geoserver import Geoserver
 
 GEO_URL = os.getenv("GEO_URL", "http://localhost:8080/geoserver")
 

--- a/tests/test_geoserver.py
+++ b/tests/test_geoserver.py
@@ -1,6 +1,7 @@
-from geo.Style import catagorize_xml, classified_xml
-from common import geo
 import pytest
+from common import geo
+
+from geo.Style import catagorize_xml, classified_xml
 
 
 @pytest.mark.skip(reason="Only setup for local testing.")
@@ -83,7 +84,7 @@ class TestFeatures:
         )
         # assert a == "something we expect"
 
-        a = geo.get_featurestore("fdemo", "demo")
+        a = geo.get_featurestore("fdemo", "demo")  # noqa: F841
         # assert a == "something we expect"
 
     def test_sql_featurestore(self):

--- a/tests/test_geoserver.py
+++ b/tests/test_geoserver.py
@@ -1,0 +1,157 @@
+from geo.Style import catagorize_xml, classified_xml
+from common import geo
+import pytest
+
+
+@pytest.mark.skip(reason="Only setup for local testing.")
+class TestRequest:
+    def test_information(self):
+        geo.get_version()
+        geo.get_manifest()
+        geo.get_status()
+        geo.get_system_status()
+
+    def test_datastore_create(self):
+        a = geo.create_shp_datastore(
+            r"C:\Program Files (x86)\GeoServer 2.15.1\data_dir\data\demo\C_Jamoat\C_Jamoat.zip",
+            store_name="111",
+        )
+        # assert a == "something we expect"
+        print(a)
+        geo.get_layer("jamoat-db", workspace="demo")
+        geo.get_datastore("111", "demo")
+        geo.get_style(
+            "hazard_exp",
+            workspace="geoinformatics_center",
+        )
+        a = geo.get_styles()
+        # assert a == "something we expect"
+
+        a = geo.create_datastore(
+            "datastore4",
+            r"http://localhost:8080/geoserver/wfs?request=GetCapabilities",
+            workspace="demo",
+            overwrite=True,
+        )
+        # assert a == "something we expect"
+
+        a = geo.create_shp_datastore(
+            r"C:\Users\tek\Desktop\try\geoserver-rest\data\A_Admin_boundaries\A_Country\A_Country.zip",
+            "aaa",
+            "default",
+        )
+        # assert a == "something we expect"
+        print(a)
+
+        geo.publish_featurestore("datastore2", "admin_units", workspace="demo")
+
+
+@pytest.mark.skip(reason="Only setup for local testing.")
+class TestCoverages:
+    def test_coverage(self):
+        geo.create_coveragestore(
+            r"C:\Users\tek\Desktop\try\geoserver-rest\data\C_EAR\a_Agriculture\agri_final_proj.tif",
+            workspace="demo",
+            lyr_name="name_try",
+            overwrite=False,
+        )
+        geo.upload_style(
+            r"C:\Users\tek\Desktop\try_sld.sld", sld_version="1.1.0", workspace="try"
+        )
+        geo.publish_style("agri_final_proj", "dem", "demo")
+        color_ramp1 = {"value1": "#ffff55", "value2": "#505050", "value3": "#404040"}
+        geo.create_coveragestyle(
+            style_name="demo",
+            raster_path=r"C:\Users\tek\Desktop\try\geoserver-rest\data\flood_alert.tif",
+            workspace="demo",
+            color_ramp=color_ramp1,
+            cmap_type="values",
+            overwrite=True,
+        )
+
+
+@pytest.mark.skip(reason="Only setup for local testing.")
+class TestFeatures:
+    def test_featurestore(self):
+        geo.create_featurestore(store_name="fdemo", workspace="demo")
+        geo.publish_featurestore("fdemo", "zones", "demo")
+        a = geo.get_featuretypes(workspace="demo", store_name="fdemo")
+        # assert a == "something we expect"
+
+        a = geo.get_feature_attribute(
+            feature_type_name="jamoat-db", workspace="demo", store_name="fdemo"
+        )
+        # assert a == "something we expect"
+
+        a = geo.get_featurestore("fdemo", "demo")
+        # assert a == "something we expect"
+
+    def test_sql_featurestore(self):
+        store_name = "geoinformatics_center"
+        name = "sql_view_test"
+        sql = 'select id, geom, "BU" from geoinformatics_center.exp_ear'
+        key_column = "BU"
+        workspace = "geoinformatics_center"
+        geo.delete_layer(name, workspace=workspace)
+        a = geo.publish_featurestore_sqlview(
+            store_name,
+            name,
+            sql,
+            key_column=key_column,
+            geom_name="geom",
+            geom_type="Geometry",
+            workspace="geoinformatics_center",
+        )
+        # assert a == "something we expect"
+        print(a)
+
+
+@pytest.mark.skip(reason="Only setup for local testing.")
+class TestStyles:
+    def test_styles(self):
+        geo.create_outline_featurestyle(
+            "demo", geom_type="polygon", workspace="demo", overwrite=True
+        )
+        catagorize_xml(
+            "kamal", [1, 2, 3, 4, 5, 6, 7], num_of_class=30, geom_type="line"
+        )
+        geo.create_catagorized_featurestyle(
+            "kamal2", [1, 2, 3, 4, 5, 6, 7], workspace="demo"
+        )
+
+
+@pytest.mark.skip(reason="Only setup for local testing.")
+class TestPostGres:
+    from geo.Postgres import Db
+
+    pg = Db(dbname="postgres", user="postgres", password="admin", host="localhost")
+
+    def test_postgres(self):
+        print(self.pg.get_columns_names("zones"))
+        # assert self.pg.get_columns_names("zones") == "something we expect"
+        print(self.pg.get_all_values("zones", "shape_area"))
+        # assert self.pg.get_columns_names("zones") == "something we expect"
+        self.pg.create_schema("kamal kshetri")
+        a = self.pg.get_columns_names("jamoat-db")
+        print(a)
+        # assert a == "something we expect"
+        a = self.pg.get_all_values("jamoat-db", "shape_area")[5]
+        print(a)
+        # assert a == "something we expect"
+
+
+@pytest.mark.skip(reason="Only setup for local testing.")
+class TestDeletion:
+    # There needs to be a setup here first before we can delete anything
+
+    def test_delete(self):
+        geo.delete_workspace(workspace="demo")
+        geo.delete_layer(layer_name="agri_final_proj", workspace="demo")
+        geo.delete_featurestore(featurestore_name="feature_store", workspace="demo")
+        geo.delete_coveragestore(coveragestore_name="store_name", workspace="demo")
+        geo.delete_style(style_name="kamal2", workspace="demo")
+
+
+class TestOther:
+    def test_classified_xml(self):
+        classified_xml("test", "kamal", [4, 5, 3, 12], color_ramp="hot")


### PR DESCRIPTION
This contributes to #45 and #46 but doesn't close them. That will be done in another PR.

This adds a lot to the code base, so I'll give a brief explanation:
* I've added docstrings to most functions. The first line of the docstring should be a sentence explaining what the function does, the following information resembles `rst` documentation fields (`Parameters`, `Returns`, `Notes`, `Example`, and other fields can be placed in the docstring, but **there are rules**. See: https://numpydoc.readthedocs.io/en/latest/format.html)
* I've also added static types to the call signatures of functions. This makes it so that IDEs can "guess" what the function needs as you type it (and raises warnings if you aren't giving a signature what it asks for; e.g. passing a `str` to something that wants and `int`).
* I've also added an example for running `pytest`. The tests that are currently written only work for you (@iamtekson), so I've marked them to be skipped. If you want to run them yourself, you need to comment out the `@pytest.mark.skip()` and treat each `class` as a self-contained test (ie: if you are testing a delete function, the setup for that class of tests should include creating a thing that will be deleted first).
* Finally, I also renamed a few objects as they renamed existing functions in the python namespace (`min` and `max`) or they broke some `PEP8` suggestions (objects should not have capital letters, e.g. `N` → `n`).

If you have any questions, feel free to ping me. 
