### PR TITLE
Rearranging and fixing problems within create_featurestore method and adding new method "edit_featuretype"

### DIFF
--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -641,7 +641,7 @@ class Geoserver:
                 <entry key="host">{3}</entry>
                 <entry key="port">{4}</entry>
                 <entry key="user">{5}</entry>
-                <entry key="password">{6}</entry>
+                <entry key="passwd">{6}</entry>
                 <entry key="dbtype">postgis</entry>
                 <entry key="schema">{7}</entry>
                 <entry key="database">{8}</entry>


### PR DESCRIPTION
I was able to fix the problem with a couple of connection parameter settings (e.g. expose primary keys) in the create_featurestore method. It was more like a .xml format problem. However, I added the missing default parameters for the connection pool.

Furthermore, I added a method called "edit_featuretype" to change name and title of the published feature.

I tested this version locally within geoserver applications and it worked very well.

Cheers, Julius