### PR TITLE
Added methods to update and delete layergroups

### DIFF
--- a/docs/source/change_log.rst
+++ b/docs/source/change_log.rst
@@ -14,6 +14,9 @@ Change Log
 * Removed ``key_column`` parameter and added ``srid`` parameter (coordinate system of the layer, default is 4326) from ``publish_featurestore_sqlview`` function
 * Solved the Bug `#73 <https://github.com/gicait/geoserver-rest/issues/73>`_ and `#69 <https://github.com/gicait/geoserver-rest/issues/69>`_
 * ``create_layergroup`` function added
+* ``update_layergroup`` function added
+* ``delete_layergroup`` function added
+*  Added layer and workspace checks to layergroup methods 
 
 
 ``[V2.1.2 - 2021-10-14]``

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -68,6 +68,8 @@ class Geoserver:
             return requests.get(url, auth=(self.username, self.password), **kwargs)
         elif method == "put":
             return requests.put(url, auth=(self.username, self.password), **kwargs)
+        elif method == "delete":
+            return requests.delete(url, auth=(self.username, self.password), **kwargs)
 
     # _______________________________________________________________________________________________
     #
@@ -82,7 +84,7 @@ class Geoserver:
         """
         try:
             url = "{}/about/manifest.json".format(self.service_url)
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -94,7 +96,7 @@ class Geoserver:
         """
         try:
             url = "{}/rest/about/version.json".format(self.service_url)
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -106,7 +108,7 @@ class Geoserver:
         """
         try:
             url = "{}/about/status.json".format(self.service_url)
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -118,7 +120,7 @@ class Geoserver:
         """
         try:
             url = "{}/about/system-status.json".format(self.service_url)
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -134,7 +136,7 @@ class Geoserver:
         """
         try:
             url = "{}/reload".format(self.service_url)
-            r = requests.post(url, auth=(self.username, self.password))
+            r = self._requests("post", url)
             return "Status code: {}".format(r.status_code)
 
         except Exception as e:
@@ -177,7 +179,7 @@ class Geoserver:
                 self.service_url, workspace, store_name
             )
 
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -195,7 +197,7 @@ class Geoserver:
                 workspace = "default"
 
             url = "{}/workspaces/{}/datastores.json".format(self.service_url, workspace)
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -220,7 +222,7 @@ class Geoserver:
             url = "{}/workspaces/{}/coveragestores/{}.json".format(
                 self.service_url, workspace, coveragestore_name
             )
-            r = requests.get(url, auth=(self.username, self.password), params=payload)
+            r = self._requests(method="get", url=url, params=payload)
             # print("Status code: {}, Get coverage store".format(r.status_code))
 
             return r.json()
@@ -237,7 +239,7 @@ class Geoserver:
                 workspace = "default"
 
             url = "{}/workspaces/{}/coveragestores".format(self.service_url, workspace)
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -291,14 +293,14 @@ class Geoserver:
         r = None
         try:
             with open(path, "rb") as f:
-                r = requests.put(
-                    url, data=f, auth=(self.username, self.password), headers=headers
-                )
+                r = self._requests(method="put", url=url, data=f, headers=headers)
 
-            if r.status_code != 201:
-                return "{}: The coveragestore can not be created!".format(r.status_code)
-            else:
-                return "The coveragestore has been created successfully!"
+                if r.status_code != 201:
+                    return "{}: The coveragestore can not be created!".format(
+                        r.status_code
+                    )
+                else:
+                    return "The coveragestore has been created successfully!"
 
         except Exception as e:
             return "Error: {}".format(e)
@@ -356,11 +358,8 @@ class Geoserver:
 
         r = None
         try:
-            r = requests.put(
-                url,
-                data=time_dimension_data,
-                auth=(self.username, self.password),
-                headers=headers,
+            r = self._requests(
+                method="put", url=url, data=time_dimension_data, headers=headers
             )
 
             if r.status_code not in [200, 201]:
@@ -388,7 +387,7 @@ class Geoserver:
                     self.service_url, workspace, layer_name
                 )
 
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -404,7 +403,7 @@ class Geoserver:
 
             if workspace is not None:
                 url = "{}/workspaces/{}/layers".format(self.service_url, workspace)
-            r = requests.get(url, auth=(self.username, self.password))
+            r = r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -427,9 +426,7 @@ class Geoserver:
             if workspace is None:
                 url = "{}/layers/{}".format(self.service_url, layer_name)
 
-            r = requests.delete(
-                url, auth=(self.username, self.password), params=payload
-            )
+            r = self._requests(method="delete", url=url, params=payload)
             if r.status_code == 200:
                 return "Status code: {}, delete layer".format(r.status_code)
 
@@ -458,7 +455,7 @@ class Geoserver:
 
             if workspace is not None:
                 url = "{}/workspaces/{}/layergroups".format(self.service_url, workspace)
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -475,7 +472,7 @@ class Geoserver:
                     self.service_url, workspace, layer_name
                 )
 
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -646,7 +643,7 @@ class Geoserver:
                     self.service_url, workspace, style_name
                 )
 
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -661,7 +658,7 @@ class Geoserver:
 
             if workspace is not None:
                 url = "{}/workspaces/{}/styles.json".format(self.service_url, workspace)
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -716,13 +713,7 @@ class Geoserver:
 
         r = None
         try:
-            r = requests.post(
-                url,
-                data=style_xml,
-                auth=(self.username, self.password),
-                headers=headers,
-            )
-
+            r = self._requests(method="post", url=url, data=style_xml, headers=headers)
             with open(path, "rb") as f:
                 r_sld = requests.put(
                     url + "/" + name,
@@ -801,10 +792,10 @@ class Geoserver:
 
         r = None
         try:
-            r = requests.post(
+            r = self._requests(
+                "post",
                 url,
                 data=style_xml,
-                auth=(self.username, self.password),
                 headers=headers,
             )
 
@@ -873,18 +864,18 @@ class Geoserver:
 
         r = None
         try:
-            r = requests.post(
+            r = self._requests(
+                "post",
                 url,
                 data=style_xml,
-                auth=(self.username, self.password),
                 headers=headers,
             )
 
             with open("style.sld", "rb") as f:
-                r_sld = requests.put(
+                r_sld = self._requests(
+                    "put",
                     url + "/" + style_name,
                     data=f.read(),
-                    auth=(self.username, self.password),
                     headers=header_sld,
                 )
                 if r_sld.status_code not in [200, 201]:
@@ -940,18 +931,18 @@ class Geoserver:
 
         r = None
         try:
-            r = requests.post(
+            r = self._requests(
+                "post",
                 url,
                 data=style_xml,
-                auth=(self.username, self.password),
                 headers=headers,
             )
 
             with open("style.sld", "rb") as f:
-                r_sld = requests.put(
+                r_sld = self._requests(
+                    "put",
                     url + "/" + style_name,
                     data=f.read(),
-                    auth=(self.username, self.password),
                     headers=header_sld,
                 )
                 if r_sld.status_code not in [200, 201]:
@@ -1015,18 +1006,18 @@ class Geoserver:
 
         r = None
         try:
-            r = requests.post(
+            r = self._requests(
+                "post",
                 url,
                 data=style_xml,
-                auth=(self.username, self.password),
                 headers=headers,
             )
 
             with open("style.sld", "rb") as f:
-                r_sld = requests.put(
+                r_sld = self._requests(
+                    "put",
                     url + "/" + style_name,
                     data=f.read(),
-                    auth=(self.username, self.password),
                     headers=header_sld,
                 )
                 if r_sld.status_code not in [200, 201]:
@@ -1073,10 +1064,10 @@ class Geoserver:
 
         r = None
         try:
-            r = requests.put(
+            r = self._requests(
+                "put",
                 url,
                 data=style_xml,
-                auth=(self.username, self.password),
                 headers=headers,
             )
 
@@ -1101,9 +1092,7 @@ class Geoserver:
             if workspace is None:
                 url = "{}/styles/{}".format(self.service_url, style_name)
 
-            r = requests.delete(
-                url, auth=(self.username, self.password), params=payload
-            )
+            r = self._requests("delete", url, params=payload)
 
             if r.status_code == 200:
                 return "Status code: {}, delete style".format(r.status_code)
@@ -1126,7 +1115,7 @@ class Geoserver:
         """
         try:
             url = "{}/workspaces/default".format(self.service_url)
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -1140,7 +1129,7 @@ class Geoserver:
         try:
             payload = {"recurse": "true"}
             url = "{}/workspaces/{}.json".format(self.service_url, workspace)
-            r = requests.get(url, auth=(self.username, self.password), params=payload)
+            r = self._requests("get", url, params=payload)
             if r.status_code == 200:
                 return r.json()
             else:
@@ -1155,7 +1144,7 @@ class Geoserver:
         """
         try:
             url = "{}/workspaces".format(self.service_url)
-            r = requests.get(url, auth=(self.username, self.password))
+            r = self._requests("get", url)
             return r.json()
 
         except Exception as e:
@@ -1169,10 +1158,10 @@ class Geoserver:
             url = "{}/workspaces/default".format(self.service_url)
             data = "<workspace><name>{}</name></workspace>".format(workspace)
             print(url, data)
-            r = requests.put(
+            r = self._requests(
+                "put",
                 url,
-                data,
-                auth=(self.username, self.password),
+                data=data,
                 headers={"content-type": "text/xml"},
             )
 
@@ -1194,9 +1183,7 @@ class Geoserver:
             url = "{}/workspaces".format(self.service_url)
             data = "<workspace><name>{}</name></workspace>".format(workspace)
             headers = {"content-type": "text/xml"}
-            r = requests.post(
-                url, data, auth=(self.username, self.password), headers=headers
-            )
+            r = self._requests("post", url, data=data, headers=headers)
 
             if r.status_code == 201:
                 return "{} Workspace {} created!".format(r.status_code, workspace)
@@ -1221,9 +1208,7 @@ class Geoserver:
         try:
             payload = {"recurse": "true"}
             url = "{}/workspaces/{}".format(self.service_url, workspace)
-            r = requests.delete(
-                url, auth=(self.username, self.password), params=payload
-            )
+            r = self._requests("delete", url, params=payload)
 
             if r.status_code == 200:
                 return "Status code: {}, delete workspace".format(r.status_code)
@@ -1388,10 +1373,10 @@ class Geoserver:
                     self.service_url, workspace, store_name
                 )
 
-                r = requests.put(
+                r = self._requests(
+                    "put",
                     url,
                     data=database_connection,
-                    auth=(self.username, self.password),
                     headers=headers,
                 )
 
@@ -1400,10 +1385,10 @@ class Geoserver:
                         r.status_code, r.content
                     )
             else:
-                r = requests.post(
+                r = self._requests(
+                    "post",
                     url,
                     data=database_connection,
-                    auth=(self.username, self.password),
                     headers=headers,
                 )
 
@@ -1461,15 +1446,11 @@ class Geoserver:
                 url = "{}/workspaces/{}/datastores/{}".format(
                     self.service_url, workspace, name
                 )
-                r = requests.put(
-                    url, data, auth=(self.username, self.password), headers=headers
-                )
+                r = self._requests("put", url, data=data, headers=headers)
 
             else:
                 url = "{}/workspaces/{}/datastores".format(self.service_url, workspace)
-                r = requests.post(
-                    url, data, auth=(self.username, self.password), headers=headers
-                )
+                r = self._requests("post", url, data=data, headers=headers)
 
             if r.status_code in [200, 201]:
                 return "Data store created/updated successfully"
@@ -2076,3 +2057,6 @@ class Geoserver:
 
         except Exception as e:
             return "Error: {}".format(e)
+
+
+print(Geoserver().get_manifest())

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -1305,35 +1305,35 @@ class Geoserver:
 
         database_connection = """
                 <dataStore>
-                <name>{0}</name>
-                <description>{1}</description>
+                <name>{}</name>
+                <description>{}</description>
                 <connectionParameters>
-                <entry key="Expose primary keys">{2}</entry>
-                <entry key="host">{3}</entry>
-                <entry key="port">{4}</entry>
-                <entry key="user">{5}</entry>
-                <entry key="passwd">{6}</entry>
+                <entry key="Expose primary keys">{}</entry>
+                <entry key="host">{}</entry>
+                <entry key="port">{}</entry>
+                <entry key="user">{}</entry>
+                <entry key="passwd">{}</entry>
                 <entry key="dbtype">postgis</entry>
-                <entry key="schema">{7}</entry>
-                <entry key="database">{8}</entry>
-                <entry key="Evictor run periodicity">{9}</entry>
-                <entry key="Max open prepared statements">{10}</entry>
-                <entry key="encode functions">{11}</entry>
-                <entry key="Primary key metadata table">{12}</entry>
-                <entry key="Batch insert size">{13}</entry>
-                <entry key="preparedStatements">{14}</entry>
-                <entry key="Estimated extends">{15}</entry>
-                <entry key="fetch size">{16}</entry>
-                <entry key="validate connections">{17}</entry>
-                <entry key="Support on the fly geometry simplification">{18}</entry>
-                <entry key="Connection timeout">{19}</entry>
-                <entry key="create database">{20}</entry>
-                <entry key="min connections">{21}</entry>
-                <entry key="max connections">{22}</entry>
-                <entry key="Evictor tests per run">{23}</entry>
-                <entry key="Test while idle">{24}</entry>
-                <entry key="Max connection idle time">{25}</entry>
-                <entry key="Loose bbox">{26}</entry>
+                <entry key="schema">{}</entry>
+                <entry key="database">{}</entry>
+                <entry key="Evictor run periodicity">{}</entry>
+                <entry key="Max open prepared statements">{}</entry>
+                <entry key="encode functions">{}</entry>
+                <entry key="Primary key metadata table">{}</entry>
+                <entry key="Batch insert size">{}</entry>
+                <entry key="preparedStatements">{}</entry>
+                <entry key="Estimated extends">{}</entry>
+                <entry key="fetch size">{}</entry>
+                <entry key="validate connections">{}</entry>
+                <entry key="Support on the fly geometry simplification">{}</entry>
+                <entry key="Connection timeout">{}</entry>
+                <entry key="create database">{}</entry>
+                <entry key="min connections">{}</entry>
+                <entry key="max connections">{}</entry>
+                <entry key="Evictor tests per run">{}</entry>
+                <entry key="Test while idle">{}</entry>
+                <entry key="Max connection idle time">{}</entry>
+                <entry key="Loose bbox">{}</entry>
                 </connectionParameters>
                 </dataStore>
                 """.format(


### PR DESCRIPTION
The following were implemented in this PR
- Reverted back to previous URL as mentioned here
- Implemented layergroup delete
- Implemented layergroup update
   - Geoserver does not support update on layergroup name and workspace. So I could only implement update to support for the title, abstract text, metadata and keywords.
   - I actually tried updating  a layer, it worked. But it removed previous layers from the layergroup. So I removed layer updating from the `update_layergroup` method. I will create another function to add layers to layer group as suggested [here](https://github.com/gicait/geoserver-rest/issues/64).
- I also added some checks e.g to confirm if a layer is valid in Geoserver and if a workspace is valid as well. I also validated if a layergroup is valid during layergroup update and deletion.
- Some other minor bug fixes.
- TODO: Tests for these methods and the add_layer_to_layergroup method.
I will work on these in the next PR and I once the add_layer_to_layergroup method is implemented, we can close that [issue](https://github.com/gicait/geoserver-rest/issues/64).