### PR TITLE
Issue 86 missing application json

### DIFF
--- a/docs/source/change_log.rst
+++ b/docs/source/change_log.rst
@@ -4,6 +4,8 @@ Change Log
 ``Master branch``
 ^^^^^^^^^^^^^^^^^
 
+* Fix json-bug in create_coveragestore method (see issue `#86 <https://github.com/gicait/geoserver-rest/issues/86>`)
+
 ``[v2.4.0 - 2023-01-10]``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Fix the import issue, close `#76 <https://github.com/gicait/geoserver-rest/issues/76>`_

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -452,7 +452,7 @@ class Geoserver:
             self.service_url, workspace, layer_name, file_type
         )
 
-        headers = {"content-type": content_type}
+        headers = {"content-type": content_type, "Accept" : "application/json"}
 
         r = None
         try:


### PR DESCRIPTION
Fixes the json-problem with create_coveragestore mentioned in #86.

I have however not checked if there are any other methods that still may have the same problem.