### PR TITLE
Layergroup creation bugfix

### DIFF
--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -728,6 +728,17 @@ class Geoserver:
                 raise Exception(
                     f"Format not supported. Acceptable formats are : {supported_formats}"
                 )
+            
+            # check if it already exist in Geoserver
+            try:
+                existing_layergroup = self.get_layergroup(name)
+            except:
+                existing_layergroup = None
+
+            if existing_layergroup is not None:
+                raise Exception(
+                    f"Layergroup: {name} already exist in Geoserver instance"
+                )
 
             if len(layers) == 0:
                 raise Exception("No layer provided!")

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -645,6 +645,8 @@ class Geoserver:
             r = self._requests("get", url)
             if r.status_code == 200:
                 return r.json()
+            elif r.status_code == 404:
+                return None
             else:
                 raise GeoserverException(r.status_code, r.content)
 

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -645,8 +645,6 @@ class Geoserver:
             r = self._requests("get", url)
             if r.status_code == 200:
                 return r.json()
-            elif r.status_code == 404:
-                return None
             else:
                 raise GeoserverException(r.status_code, r.content)
 
@@ -729,11 +727,6 @@ class Geoserver:
 
                 raise Exception(
                     f"Format not supported. Acceptable formats are : {supported_formats}"
-                )
-            # check if it already exist in Geoserver
-            if self.get_layergroup(name) is not None:
-                raise Exception(
-                    f"Layergroup: {name} already exist in Geoserver instance"
                 )
 
             if len(layers) == 0:


### PR DESCRIPTION
Hi,

Geoserver now returns 404 HTTP error code when requesting for a resource that doesn't exists (instead of 200 OK with empty JSON before I imagine)

This impacts the layergroup creation method as it checks a layergroup with the same name doesn't exists already.

Best regards