### PR TITLE
Bugfix: add/remove layer to layergroup

### DIFF
--- a/docs/source/change_log.rst
+++ b/docs/source/change_log.rst
@@ -3,6 +3,7 @@ Change Log
 
 ``Master branch``
 ^^^^^^^^^^^^^^^^^
+* Bugfixes for `add_layer_to_layergroup` and `remove_layer_from_layergroup`
 * New method `remove_layer_from_layergroup`
 
 ``[v2.4.1 - 2023-01-14]``

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -1006,11 +1006,11 @@ class Geoserver:
 
         # build list of existing publishables & styles
         publishables = layergroup_info["layerGroup"]["publishables"]["published"]
-        if isinstance(publishables, dict): # only 1 layer up to now
+        if not isinstance(publishables, list): # only 1 layer up to now
             publishables = [publishables]
 
         styles = layergroup_info["layerGroup"]["styles"]["style"]
-        if isinstance(styles, str): # only 1 layer up to now
+        if not isinstance(styles, list): # only 1 layer up to now
             styles = [styles]
 
         # add publishable & style for the new layer
@@ -1074,11 +1074,11 @@ class Geoserver:
 
         # build list of existing publishables & styles
         publishables = layergroup_info["layerGroup"]["publishables"]["published"]
-        if isinstance(publishables, dict): # only 1 layer up to now
+        if not isinstance(publishables, list): # only 1 layer up to now
             publishables = [publishables]
 
         styles = layergroup_info["layerGroup"]["styles"]["style"]
-        if isinstance(styles, str): # only 1 layer up to now
+        if not isinstance(styles, list): # only 1 layer up to now
             styles = [styles]
 
         layer_to_remove = f"{layer_workspace}:{layer_name}"


### PR DESCRIPTION
#### Bug description:
- The Geoserver API returns lists for styles & publishables in a layergroup in case the layergroup contains more than one layer; if the layergroup contains only one layer, however, "styles" may either be a string or a dictionary. 
- The current implementation of add_layer_to_layergroup would however only check if styles is a string and thus fail when confronted with a dictionary.

#### Solution description:
- The "single-layer" check now checks for "is not a list" rather than for "is a string"