### PR TITLE
Update development and installation instructions

### DIFF
--- a/DEV_DOCS.md
+++ b/DEV_DOCS.md
@@ -4,17 +4,17 @@
 
 For publishing the python package, follow following steps,
 
-1. install twine `pip install twine`
-2. create dist folder by running setup.py file `python setup.py bdist_wheel sdist`
+1. Install twine `pip install twine`
+2. Generate packages and create dist folder by running setup.py file `python setup.py bdist_wheel sdist`
 3. Push to PyPI `twine upload dist/*`
 
 ### Pre-commit Reference
 
-To install the additional libraries for dev (testing, formatting etc) run `pip install --editable .[dev]`
+To install the additional libraries for dev (testing, formatting, etc.) run `pip install --editable .[dev]`
 
-[`pre-commit`](https://pre-commit.com/) is a pretty standard tooling-helper for automating the formatting of code (isort, black, end-of-file-fixer, trailing-space-fixer, etc.) and evaluating any potential issues (flake8). This essentially makes all code contributions look the same no matter what in order to favour readability/maintainability.
+[`pre-commit`](https://pre-commit.com/) is a pretty standard tooling-helper for automating the formatting of code (`isort`, `black`, `end-of-file-fixer`, `trailing-space-fixer`, etc.) and evaluating any potential issues (`flake8`). This essentially makes all code contributions look the same no matter what in order to favour readability/maintainability.
 
-Installing and running pre-commit is fairly automatic. After installing the requirements-dev.txt, run:
+Installing and running `pre-commit` is fairly automatic. After installing the requirements-dev.txt, run:
 
 ```bash
 pre-commit install
@@ -22,7 +22,7 @@ pre-commit install
 
 and the environments will be managed automatically. Any calls to git commit will run the checks. If something changes, you need to simply run git commit a second time and it should be good.
 
-Some checks will require changes (e.g. imports of pdb are a violation, unused imports, unused initialized objects, etc.). If these are needed by design you can do either of the following:
+Some checks will require changes (e.g. imports of `pdb` are a violation, unused imports, unused initialized objects, etc.). If these are needed by design you can do either of the following:
 
 To commit the files and ignore the checks (not great as checks will fail for future commits and for others):
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -75,7 +75,7 @@ For other versions of Linux, simply use your package manager to install ``gdal``
     # Arch, Manjaro, etc.
     $ sudo pacman -S gdal
     # Void Linux
-    $ sudo xbps-install -S libgdal libgdal-dev
+    $ sudo xbps-install -S libgdal libgdal-devel
 
 Now the ``pygdal`` and ``geoserver-rest`` libraries can be installed using ``pip``:
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,6 @@ The ``geoserver-rest`` can be installed from either ``conda-forge`` channel or `
     conda install -c conda-forge geoserver-rest
     conda install -c iamtekson geoserver-rest
 
-
 Pip installation
 ^^^^^^^^^^^^^^^^
 
@@ -19,39 +18,68 @@ For installation of this package, following packages should be installed first:
 
 * `GDAL <https://gdal.org/>`_
 
-
 Windows installation
 --------------------
 
-In windows, the ``gdal`` dependency can be install using ``pipwin``,
+.. warning::
+    As of March 2022, ``pipwin`` has been deprecated and is no longer maintained. Do not use this method.
+
+For Windows, the ``gdal`` dependency can be complex to install. There are a handful of ways to install ``gdal`` in Windows.
+
+One way is install the wheel directly from the `Geospatial library wheels for Python Windows <https://github.com/cgohlke/geospatial-wheels>`_ releases page. Be sure to select the wheel for your system from the latest release and install it using pip install command:
 
 .. code-block:: shell
 
-    pip install pipwin
-    pipwin refresh
-    pipwin install gdal
+    # For Python3.10 on Windows 64-bit systems
+    $ pip install https://github.com/cgohlke/geospatial-wheels/releases/download/<release_version>/GDAL-3.7.1-cp310-cp310-win_amd64.whl
 
-Now you can install the library using pip install command,
+Another way is to use the OSGeo4W network installer binary package available at: https://trac.osgeo.org/osgeo4w/.
+
+Now you can then install the library using pip install command:
 
 .. code-block:: shell
 
-    pip install geoserver-rest
+    $ pip install geoserver-rest
 
+macOS installation
+------------------
+
+For macOS, we suggest using the `homebrew` package manager to install ``gdal``. Once ``homebrew`` is installed, ``gdal`` can be installed using following method:
+
+.. code-block:: shell
+
+    brew update
+    brew install gdal
+    pip3 install pygdal=="$(gdalinfo --version | awk '{print $2}' | sed s'/.$//')"
 
 Linux installation
 ------------------
 
-In Debian/Ubuntu, ``gdal`` can be installed using following method:
+For Ubuntu specifically, we suggest installing ``gdal`` from the ``ubuntugis`` PPA:
 
 .. code-block:: shell
 
-    sudo add-apt-repository ppa:ubuntugis/ppa
-    sudo apt update -y; sudo apt upgrade -y;
-    sudo apt install gdal-bin libgdal-dev
-    pip3 install pygdal=="`gdal-config --version`.*"
+    $ sudo add-apt-repository ppa:ubuntugis/ppa
+    $ sudo apt update -y
+    $ sudo apt upgrade -y
+    $ sudo apt install gdal-bin libgdal-dev
 
-Now the geoserver-rest library can be installed using pip install command:
+For other versions of linux, simply use your package manager to install ``gdal``.
 
 .. code-block:: shell
 
-    pip install geoserver-rest
+    # Debian, Mint, etc.
+    $ sudo apt install gdal-bin libgdal-dev
+    # Fedora, RHEL, etc.
+    $ sudo yum install gdal gdal-devel
+    # Arch, Manjaro, etc.
+    $ sudo pacman -S gdal
+    # Void
+    $ sudo xbps-install -S libgdal libgdal-dev
+
+Now the ``pygdal`` and ``geoserver-rest`` library can be installed using pip install command:
+
+.. code-block:: shell
+
+    $ pip install pygdal=="`gdal-config --version`.*"
+    $ pip install geoserver-rest

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -31,11 +31,11 @@ One way is install the wheel directly from the `Geospatial library wheels for Py
 .. code-block:: shell
 
     # For Python3.10 on Windows 64-bit systems
-    $ pip install https://github.com/cgohlke/geospatial-wheels/releases/download/<release_version>/GDAL-3.7.1-cp310-cp310-win_amd64.whl
+    $ pip.exe install https://github.com/cgohlke/geospatial-wheels/releases/download/<release_version>/GDAL-3.7.1-cp310-cp310-win_amd64.whl
 
-Another way is to use the OSGeo4W network installer binary package available at: https://trac.osgeo.org/osgeo4w/.
+Another way is to use the GDAL network installer binary package available at: `OSGeo4W <https://trac.osgeo.org/osgeo4w/>`_.
 
-Now you can then install the library using pip install command:
+Now you can then install ``geoserver-rest`` library with ``pip``:
 
 .. code-block:: shell
 
@@ -48,9 +48,9 @@ For macOS, we suggest using the `homebrew` package manager to install ``gdal``. 
 
 .. code-block:: shell
 
-    brew update
-    brew install gdal
-    pip3 install pygdal=="$(gdalinfo --version | awk '{print $2}' | sed s'/.$//')"
+    $ brew update
+    $ brew install gdal
+    $ pip3 install pygdal=="$(gdalinfo --version | awk '{print $2}' | sed s'/.$//')"
 
 Linux installation
 ------------------
@@ -64,7 +64,7 @@ For Ubuntu specifically, we suggest installing ``gdal`` from the ``ubuntugis`` P
     $ sudo apt upgrade -y
     $ sudo apt install gdal-bin libgdal-dev
 
-For other versions of linux, simply use your package manager to install ``gdal``.
+For other versions of Linux, simply use your package manager to install ``gdal``.
 
 .. code-block:: shell
 
@@ -74,12 +74,12 @@ For other versions of linux, simply use your package manager to install ``gdal``
     $ sudo yum install gdal gdal-devel
     # Arch, Manjaro, etc.
     $ sudo pacman -S gdal
-    # Void
+    # Void Linux
     $ sudo xbps-install -S libgdal libgdal-dev
 
-Now the ``pygdal`` and ``geoserver-rest`` library can be installed using pip install command:
+Now the ``pygdal`` and ``geoserver-rest`` libraries can be installed using ``pip``:
 
 .. code-block:: shell
 
-    $ pip install pygdal=="`gdal-config --version`.*"
+    $ pip install pygdal=="$(gdal-config --version).*"
     $ pip install geoserver-rest


### PR DESCRIPTION
Closes #114

This updates the installation and dev instructions. I can't confirm details for Windows, but `pipwin` seems to have been deprecated entirely. It would be great if someone with a Windows machine can confirm that the approaches I found are still valid in 2023.

macOS and Linux installation workflows confirmed working in 2023 (personal experience).