### PR TITLE
Layer group creation modes

### DIFF
--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -611,10 +611,10 @@ class Geoserver:
 
         supported_modes: Set = {
             "single",
-            "opaque container",
-            "named tree",
-            "container tree",
-            "earth observation tree",
+            "opaque",
+            "named",
+            "container",
+            "eo",
         }
         supported_formats: Set = {"html", "json", "xml"}
 


### PR DESCRIPTION
The layer group creation modes were not the ones described into Geoserver rest API docs. I aligned them.