### PR TITLE
Make transparent by removing fill color option

### DIFF
--- a/geo/Style.py
+++ b/geo/Style.py
@@ -163,9 +163,6 @@ def outline_only_xml(color, geom_type="polygon"):
     elif geom_type == "polygon":
         symbolizer = """
                 <PolygonSymbolizer>
-                    <Fill>
-                        <CssParameter name="fill">#FFFFFF</CssParameter>
-                    </Fill>
                     <Stroke>
                     <CssParameter name="stroke">{}</CssParameter>
                     <CssParameter name="stroke-width">0.26</CssParameter>


### PR DESCRIPTION
Make it transparent by removing the default fill color option of white.