### PR TITLE
Changed upload_style so you can alternatively just pass valid XML in place of the path to the file containing the style XML

### DIFF
--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -2,7 +2,6 @@
 import os
 from typing import List, Optional, Set, Union
 from pathlib import Path
-import xml.etree.ElementTree as ET
 
 # third-party libraries
 import requests

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -1141,7 +1141,7 @@ class Geoserver:
                 name = f[0]
 
         if Path(path).exists():
-            # path is pointing a an existing file
+            # path is pointing to an existing file
             with open(path, "rb") as f:
                 xml = f.read()
         elif is_valid_xml(path):

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -1177,7 +1177,7 @@ class Geoserver:
                         headers=header_sld,
                     )
             else:
-                raise TypeError("`path` must be either a path to a style file, or a valid XML string.")
+                raise ValueError("`path` must be either a path to a style file, or a valid XML string.")
 
             if r_sld.status_code == 200:
                 return r_sld.status_code

--- a/geo/supports.py
+++ b/geo/supports.py
@@ -47,8 +47,7 @@ def is_valid_xml(xml_string: str) -> bool:
 
         Parameters
     ----------
-    name : name of files
-    data : dict
+    xml_string : string containing xml
 
     Returns
     -------

--- a/geo/supports.py
+++ b/geo/supports.py
@@ -2,6 +2,7 @@ import os
 from tempfile import mkstemp
 from typing import Dict
 from zipfile import ZipFile
+import xml.etree.ElementTree as ET
 
 
 def prepare_zip_file(name: str, data: Dict) -> str:
@@ -37,3 +38,26 @@ def prepare_zip_file(name: str, data: Dict) -> str:
     zip_file.close()
     os.close(fd)
     return path
+
+
+def is_valid_xml(xml_string: str) -> bool:
+
+    """
+    Returns True if string is valid XML, false otherwise
+
+        Parameters
+    ----------
+    name : name of files
+    data : dict
+
+    Returns
+    -------
+    bool
+    """
+
+    try:
+        # Attempt to parse the XML string
+        ET.fromstring(xml_string)
+        return True
+    except ET.ParseError:
+        return False

--- a/tests/data/style.sld
+++ b/tests/data/style.sld
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0"
+                       xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd"
+                       xmlns="http://www.opengis.net/sld"
+                       xmlns:ogc="http://www.opengis.net/ogc"
+                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>generic</Name>
+    <UserStyle>
+      <Title>Generic</Title>
+      <Abstract>Generic style</Abstract>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>raster</Name>
+          <Title>Opaque Raster</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:Function name="isCoverage"/>
+              <ogc:Literal>true</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <RasterSymbolizer>
+            <Opacity>1.0</Opacity>
+          </RasterSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>Polygon</Name>
+          <Title>Grey Polygon</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:Function name="dimension">
+                <ogc:Function name="geometry"/>
+              </ogc:Function>
+              <ogc:Literal>2</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#AAAAAA</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>Line</Name>
+          <Title>Blue Line</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:Function name="dimension">
+                <ogc:Function name="geometry"/>
+              </ogc:Function>
+              <ogc:Literal>1</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#0000FF</CssParameter>
+              <CssParameter name="stroke-opacity">1</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>point</Name>
+          <Title>Red Square Point</Title>
+          <ElseFilter/>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>square</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+        <VendorOption name="ruleEvaluation">first</VendorOption>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/tests/test_geoserver.py
+++ b/tests/test_geoserver.py
@@ -152,7 +152,7 @@ class TestUploadStyles:
             style = geo.get_style("style_doesnt_exist")
             print()
 
-    def test_upload_style_from_opened_file(self):
+    def test_upload_style_from_xml(self):
 
         try:
             geo.delete_style("test_upload_style")

--- a/tests/test_geoserver.py
+++ b/tests/test_geoserver.py
@@ -167,15 +167,15 @@ class TestUploadStyles:
     def test_upload_style_from_malformed_xml_fails(self):
 
         try:
-            geo.delete_style("style_doesnt_exist")
+            geo.delete_style("style_malformed")
         except GeoserverException:
             pass
 
         xml = open(f"{HERE}/data/style.sld").read()[1:]
         with pytest.raises(ValueError):
-            geo.upload_style(xml, "style_doesnt_exist")
+            geo.upload_style(xml, "style_malformed")
         with pytest.raises(GeoserverException):
-            style = geo.get_style("style_doesnt_exist")
+            style = geo.get_style("style_malformed")
 
 
 @pytest.mark.skip(reason="Only setup for local testing.")

--- a/tests/test_geoserver.py
+++ b/tests/test_geoserver.py
@@ -132,7 +132,7 @@ class TestUploadStyles:
 
         try:
             geo.delete_style("test_upload_style")
-        except geo.Geoserver.GeoserverException:
+        except GeoserverException:
             pass
 
         geo.upload_style(f"{HERE}/data/style.sld", "test_upload_style")
@@ -142,20 +142,21 @@ class TestUploadStyles:
     def test_upload_style_from_malformed_file_fails(self):
 
         try:
-            geo.delete_style("test_upload_style")
+            geo.delete_style("style_doesnt_exist")
         except GeoserverException:
             pass
 
         with pytest.raises(ValueError):
-            geo.upload_style(f"{HERE}/data/style_doesnt_exist.sld", "test_upload_style")
+            geo.upload_style(f"{HERE}/data/style_doesnt_exist.sld", "style_doesnt_exist")
         with pytest.raises(GeoserverException):
             style = geo.get_style("style_doesnt_exist")
+            print()
 
     def test_upload_style_from_opened_file(self):
 
         try:
             geo.delete_style("test_upload_style")
-        except geo.Geoserver.GeoserverException:
+        except GeoserverException:
             pass
 
         xml = open(f"{HERE}/data/style.sld").read()
@@ -166,36 +167,15 @@ class TestUploadStyles:
     def test_upload_style_from_malformed_xml_fails(self):
 
         try:
-            geo.delete_style("test_upload_style")
-            geo.delete_style("test_upload_style")
+            geo.delete_style("style_doesnt_exist")
         except GeoserverException:
             pass
 
         xml = open(f"{HERE}/data/style.sld").read()[1:]
         with pytest.raises(ValueError):
-            geo.upload_style(xml, "test_upload_style")
+            geo.upload_style(xml, "style_doesnt_exist")
         with pytest.raises(GeoserverException):
             style = geo.get_style("style_doesnt_exist")
-
-
-@pytest.mark.skip(reason="Only setup for local testing.")
-class TestPostGres:
-    from geo.Postgres import Db
-
-    pg = Db(dbname="postgres", user="postgres", password="admin", host="localhost")
-
-    def test_postgres(self):
-        print(self.pg.get_columns_names("zones"))
-        # assert self.pg.get_columns_names("zones") == "something we expect"
-        print(self.pg.get_all_values("zones", "shape_area"))
-        # assert self.pg.get_columns_names("zones") == "something we expect"
-        self.pg.create_schema("kamal kshetri")
-        a = self.pg.get_columns_names("jamoat-db")
-        print(a)
-        # assert a == "something we expect"
-        a = self.pg.get_all_values("jamoat-db", "shape_area")[5]
-        print(a)
-        # assert a == "something we expect"
 
 
 @pytest.mark.skip(reason="Only setup for local testing.")

--- a/tests/test_geoserver.py
+++ b/tests/test_geoserver.py
@@ -1,9 +1,12 @@
+import pathlib
+
 import pytest
 
 from geo.Style import catagorize_xml, classified_xml
 
 from .common import geo
 
+HERE = pathlib.Path(__file__).parent.resolve()
 
 @pytest.mark.skip(reason="Only setup for local testing.")
 class TestRequest:
@@ -120,6 +123,24 @@ class TestStyles:
         geo.create_catagorized_featurestyle(
             "kamal2", [1, 2, 3, 4, 5, 6, 7], workspace="demo"
         )
+
+
+class TestUploadStyles:
+
+    def test_upload_style_from_file(self):
+
+        geo.delete_style("test_upload_style")
+        geo.upload_style(f"{HERE}/data/style.sld", "test_upload_style")
+        style = geo.get_style("test_upload_style")
+        assert style["style"]["name"] == "test_upload_style"
+
+    def test_upload_style_from_opened_file(self):
+
+        geo.delete_style("test_upload_style")
+        xml = open(f"{HERE}/data/style.sld").read()
+        geo.upload_style(xml, "test_upload_style")
+        style = geo.get_style("test_upload_style")
+        assert style["style"]["name"] == "test_upload_style"
 
 
 @pytest.mark.skip(reason="Only setup for local testing.")

--- a/tests/test_geoserver.py
+++ b/tests/test_geoserver.py
@@ -179,6 +179,26 @@ class TestUploadStyles:
 
 
 @pytest.mark.skip(reason="Only setup for local testing.")
+class TestPostGres:
+    from geo.Postgres import Db
+
+    pg = Db(dbname="postgres", user="postgres", password="admin", host="localhost")
+
+    def test_postgres(self):
+        print(self.pg.get_columns_names("zones"))
+        # assert self.pg.get_columns_names("zones") == "something we expect"
+        print(self.pg.get_all_values("zones", "shape_area"))
+        # assert self.pg.get_columns_names("zones") == "something we expect"
+        self.pg.create_schema("kamal kshetri")
+        a = self.pg.get_columns_names("jamoat-db")
+        print(a)
+        # assert a == "something we expect"
+        a = self.pg.get_all_values("jamoat-db", "shape_area")[5]
+        print(a)
+        # assert a == "something we expect"
+
+
+@pytest.mark.skip(reason="Only setup for local testing.")
 class TestDeletion:
     # There needs to be a setup here first before we can delete anything
 

--- a/tests/test_geoserver.py
+++ b/tests/test_geoserver.py
@@ -3,6 +3,7 @@ import pathlib
 import pytest
 
 from geo.Style import catagorize_xml, classified_xml
+from geo.Geoserver import GeoserverException
 
 from .common import geo
 
@@ -129,18 +130,52 @@ class TestUploadStyles:
 
     def test_upload_style_from_file(self):
 
-        geo.delete_style("test_upload_style")
+        try:
+            geo.delete_style("test_upload_style")
+        except geo.Geoserver.GeoserverException:
+            pass
+
         geo.upload_style(f"{HERE}/data/style.sld", "test_upload_style")
         style = geo.get_style("test_upload_style")
         assert style["style"]["name"] == "test_upload_style"
 
+    def test_upload_style_from_malformed_file_fails(self):
+
+        try:
+            geo.delete_style("test_upload_style")
+        except GeoserverException:
+            pass
+
+        with pytest.raises(ValueError):
+            geo.upload_style(f"{HERE}/data/style_doesnt_exist.sld", "test_upload_style")
+        with pytest.raises(GeoserverException):
+            style = geo.get_style("style_doesnt_exist")
+
     def test_upload_style_from_opened_file(self):
 
-        geo.delete_style("test_upload_style")
+        try:
+            geo.delete_style("test_upload_style")
+        except geo.Geoserver.GeoserverException:
+            pass
+
         xml = open(f"{HERE}/data/style.sld").read()
         geo.upload_style(xml, "test_upload_style")
         style = geo.get_style("test_upload_style")
         assert style["style"]["name"] == "test_upload_style"
+
+    def test_upload_style_from_malformed_xml_fails(self):
+
+        try:
+            geo.delete_style("test_upload_style")
+            geo.delete_style("test_upload_style")
+        except GeoserverException:
+            pass
+
+        xml = open(f"{HERE}/data/style.sld").read()[1:]
+        with pytest.raises(ValueError):
+            geo.upload_style(xml, "test_upload_style")
+        with pytest.raises(GeoserverException):
+            style = geo.get_style("style_doesnt_exist")
 
 
 @pytest.mark.skip(reason="Only setup for local testing.")


### PR DESCRIPTION
Closes #116

I finally came back to this half a year later, but I made better changes than what I suggested in the issue.

You can now upload a style just by passing valid XML where you would normally pass the path to the SLD file.

I realize it's a bit janky because the parameter is called `path`, but I'm afraid that changing it might break existing systems that invoke the method via kwargs. But I think the added flexibility is worth it. To briefly re-iterate my issue, I was dynamically building style files on the fly and uploading them, and it was annoying me that I had to save them to a file before uploading them. With this change I (and others) should be able to just pass the style as XML if you don't want to bother writing to disk first.

I also wrote a couple tests to confirm that both passing a path to the file works, as does passing an XML string. I also tested that passing a non-existent path, as well as a malformed XML string fails as expected.

Sorry about the bad branch name, originally I was working on making temp files work before I realized that it would be easier to just pass a string.