### PR TITLE
Sql view params

### DIFF
--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -1,6 +1,6 @@
 # inbuilt libraries
 import os
-from typing import List, Optional, Set, Union
+from typing import List, Optional, Set, Union, Dict
 from pathlib import Path
 
 # third-party libraries
@@ -2025,6 +2025,7 @@ class Geoserver:
         name: str,
         store_name: str,
         sql: str,
+        parameters: List[Dict] = None,
         key_column: Optional[str] = None,
         geom_name: str = "geom",
         geom_type: str = "Geometry",
@@ -2054,6 +2055,20 @@ class Geoserver:
         else:
             key_column_xml = """"""
 
+        parameters_xml = ""
+        if parameters is not None:
+            for parameter in parameters:
+                param_name = parameter.get("name", "")
+                default_value = parameter.get("defaultValue", "")
+                regexp_validator = parameter.get("regexpValidator", r"^[\w\d\s]+$")
+                parameters_xml += (f"""
+                    <parameter>
+                        <name>{param_name}</name>
+                        <defaultValue>{default_value}</defaultValue>
+                        <regexpValidator>{regexp_validator}</regexpValidator>
+                    </parameter>\n
+                """.strip())
+
         layer_xml = """<featureType>
         <name>{0}</name>
         <enabled>true</enabled>
@@ -2073,11 +2088,12 @@ class Geoserver:
                         <type>{3}</type>
                         <srid>{5}</srid>
                     </geometry>{6}
+                    {7}
                 </virtualTable>
             </entry>
         </metadata>
         </featureType>""".format(
-            name, sql, geom_name, geom_type, workspace, srid, key_column_xml
+            name, sql, geom_name, geom_type, workspace, srid, key_column_xml, parameters_xml
         )
 
         # rest API url

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -1,6 +1,6 @@
 # inbuilt libraries
 import os
-from typing import List, Optional, Set, Union, Dict
+from typing import List, Optional, Set, Union, Dict, Iterable
 from pathlib import Path
 
 # third-party libraries
@@ -2025,7 +2025,7 @@ class Geoserver:
         name: str,
         store_name: str,
         sql: str,
-        parameters: List[Dict] = None,
+        parameters: Optional[Iterable[Dict]] = None,
         key_column: Optional[str] = None,
         geom_name: str = "geom",
         geom_type: str = "Geometry",
@@ -2033,18 +2033,42 @@ class Geoserver:
         workspace: Optional[str] = None,
     ):
         """
+        Publishes an SQL query as a layer, optionally with parameters
 
         Parameters
         ----------
         name : str
         store_name : str
         sql : str
+        parameters : iterable of dicts, optional
         key_column : str, optional
         geom_name : str, optional
         geom_type : str, optional
         workspace : str, optional
 
+        Notes
+        -----
+        With regards to SQL view parameters, it is advised to read the relevant section from the geoserver docs:
+        https://docs.geoserver.org/main/en/user/data/database/sqlview.html#parameterizing-sql-views
+
+        An integer-based parameter must have a default value
+
+        You should be VERY careful with the `regexp_validator`, as it can open you to SQL injection attacks. If you do
+        not supply one for a parameter, it will use the geoserver default `^[\w\d\s]+$`.
+
+        The `parameters` iterable must contain dictionaries with this structure:
+
+        ```
+        {
+          "name": "<name of parameter (required)>"
+          "rexegpValidator": "<string containing regex validator> (optional)"
+          "defaultValue" : "<default value of parameter if not specified (required only for integer parameters)>"
+        }
+        ```
         """
+
+        # TODO: test how it fails if you pass a default value to an integer type parameter
+
         if workspace is None:
             workspace = "default"
 

--- a/geo/supports.py
+++ b/geo/supports.py
@@ -1,4 +1,5 @@
 import os
+import re
 from tempfile import mkstemp
 from typing import Dict
 from zipfile import ZipFile
@@ -60,3 +61,16 @@ def is_valid_xml(xml_string: str) -> bool:
         return True
     except ET.ParseError:
         return False
+
+
+def is_surrounded_by_quotes(text, param):
+    # The regex pattern searches for '%foo%' surrounded by single quotes.
+    # It uses \'%foo%\' to match '%foo%' literally, including the single quotes.
+    pattern = rf"\'%{param}%\'"
+
+    # re.search() searches the string for the first location where the regex pattern produces a match.
+    # If a match is found, re.search() returns a match object. Otherwise, it returns None.
+    match = re.search(pattern, text)
+
+    # Return True if a match is found, False otherwise.
+    return bool(match)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,5 @@ sphinx>=1.7
 pre-commit
 environs
 ddt
+sqlalchemy>=2.0.29
+psycopg2>=2.9.9

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,6 +2,21 @@ import os
 
 from geo.Geoserver import Geoserver
 
-GEO_URL = os.getenv("GEO_URL", "http://localhost:8080/geoserver")
+GEO_URL = os.getenv("GEO_URL", "http://localhost:8080/geoserver")  # relative to test machine
 
-geo = Geoserver(GEO_URL, username="admin", password="geoserver")
+geo = Geoserver(GEO_URL, username=os.getenv("GEO_USER", "admin"), password=os.getenv("GEO_PASS", "geoserver"))
+
+postgis_params = {
+    "host": os.getenv("DB_HOST", "localhost"),  # relative to the geoserver instance
+    "port": os.getenv("DB_PORT", "5432"),  # relative to the geoserver instance
+    "db": os.getenv("DB_NAME", "geodb"),
+    "pg_user": os.getenv("DB_USER", "geodb_user"),
+    "pg_password": os.getenv("DB_PASS", "geodb_pass")
+}
+
+# in case you are using docker or something, and the location of the database is different relative to your host machine
+postgis_params_local_override = {
+    "host": os.getenv("DB_HOST_LOCAL", "localhost"),  # relative to the test machine
+    "port": os.getenv("DB_PORT_LOCAL", "5432"),  # relative to the test machine
+}
+postgis_params_local = {**postgis_params, **postgis_params_local_override}


### PR DESCRIPTION
Howdy howdy and happy Friday

I needed expanded functionality for specifying parameters in published SQL View layers, so I have implemented it into the `publish_featurestore_sqlview` method.

Specific things to note:

* New optional parameter `parameters`, which is an iterable of dicts with names that correspond (snake_case to camelCase) to the necessary XML entries used by Geoserver to define the parameters for SQL Views ([docs](https://docs.geoserver.org/main/en/user/data/database/sqlview.html#parameterizing-sql-views))
* Totally reworked `TestFeatures` to account for these changes, and made it automatically build up the necessary database and geoserver content, and tearing it down at the end.
* To the above point, I also expanded the stuff in `tests/common.py` to allow you to specify a database in which to run tests. Maybe some of the current "local only" tests can be refactored to use this as well.
* Two new dev dependencies were introduced, I hope that that isn't a problem. They are `sqlalchemy` and `psycopg2`, used to work with the database when setting up & tearing down the database during testing.
* 
Let me know what you think, I can tweak this further