### PR TITLE
Changed order of xml validating vs. opening SLD file path to stop crashes on windows due to file path length

### DIFF
--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -1140,13 +1140,13 @@ class Geoserver:
             if len(f) > 0:
                 name = f[0]
 
-        if Path(path).exists():
+        if is_valid_xml(path):
+            # path is actually just the xml itself
+            xml = path
+        elif Path(path).exists():
             # path is pointing to an existing file
             with open(path, "rb") as f:
                 xml = f.read()
-        elif is_valid_xml(path):
-            # path is actually just the xml itself
-            xml = path
         else:
             # path is non-existing file or not valid xml
             raise ValueError("`path` must be either a path to a style file, or a valid XML string.")


### PR DESCRIPTION
Fixes issue identified in https://github.com/gicait/geoserver-rest/issues/147

I only ever tested in a Linux environment where the path length for a file is effectively unlimited, but it will fail in a Windows environment due to a length limit of 254 characters.