### PR TITLE
Update Geoserver.py

### DIFF
--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -2688,7 +2688,7 @@ class Geoserver:
         headers = {"content-type": "text/xml"}
 
         # request
-        r = self.requests("post", url, data=layer_xml, headers=headers)
+        r = self._requests("post", url, data=layer_xml, headers=headers)
 
         if r.status_code == 201:
             return r.status_code


### PR DESCRIPTION
Fixed wrong call to self.requests instead of self._requests

@iamtekson I saw that there were a couple of other instances of this that you already patched. I'm just wondering, did these not get picked up by the tests somehow? On my fork, the test for this function failed immediately since the object has no `requests` property.