### PR TITLE
make gdal dep optional

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   deploy:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   deploy:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -15,7 +15,7 @@ jobs:
 
   test-ubuntu:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -15,7 +15,7 @@ jobs:
 
   test-ubuntu:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -15,7 +15,7 @@ jobs:
 
   test-ubuntu:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/docs/source/how_to_use.rst
+++ b/docs/source/how_to_use.rst
@@ -144,6 +144,8 @@ Before uploading ``SLD`` file, please check the version of your sld file. By def
 Creating and applying dynamic styles based on the raster coverages
 ------------------------------------------------------------------
 
+**WARNING:** As of version 2.9.0, the required dependency ``gdal`` was converted into an optional dependency. Fresh installations of this library will require that you then install ``gdal`` yourself with ``pip install gdal``.
+
 It is used to create the style file for raster data. You can get the ``color_ramp`` name from `matplotlib colormaps <https://matplotlib.org/3.3.0/tutorials/colors/colormaps.html>`_. By default ``color_ramp='RdYlGn'`` (red to green color ramp).
 
 .. code-block:: python

--- a/geo/Calculation_gdal.py
+++ b/geo/Calculation_gdal.py
@@ -4,6 +4,8 @@ try:
     from osgeo import gdal  # noqa
 except ImportError:
     import gdal  # noqa
+except ImportError:
+    raise ImportError("Package `gdal` is required to run this function. Install it with `pip install gdal`.")
 
 
 def raster_value(path: str) -> dict:

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -8,7 +8,6 @@ import requests
 from xmltodict import parse, unparse
 
 # custom functions
-from .Calculation_gdal import raster_value
 from .Style import catagorize_xml, classified_xml, coverage_style_xml, outline_only_xml
 from .supports import prepare_zip_file, is_valid_xml, is_surrounded_by_quotes
 
@@ -1611,6 +1610,9 @@ class Geoserver:
         This function will dynamically create the style file for raster.
         Inputs: name of file, workspace, cmap_type (two options: values, range), ncolors: determines the number of class, min for minimum value of the raster, max for the max value of raster
         """
+
+        from .Calculation_gdal import raster_value
+
         raster = raster_value(raster_path)
         min_value = raster["min"]
         max_value = raster["max"]

--- a/geo/__version__.py
+++ b/geo/__version__.py
@@ -4,4 +4,4 @@
 
 __author__ = "Tek Kshetri"
 __email__ = "iamtekson@gmail.com"
-__version__ = "2.8.3"
+__version__ = "2.9.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pygments
 requests
 seaborn
 matplotlib
-xmltodic
+xmltodict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pygments
 requests
 seaborn
-gdal
 matplotlib
-xmltodict
+xmltodic


### PR DESCRIPTION
GDAL can be very cumbersome to install, since it is a Python wrapper to a system binary. That system binary is also notoriously difficult to deal with, as newer versions of Linux (at least Ubuntu) stop adding newer versions to old apt repositories. As a result, it can cause serious headaches with dependency management. It gets even worse when using stricter package management systems, like poetry.

As far as I can tell, this library only actually needs GDAL for one function (`create_coveragestyle`). This PR removes GDAL from `requirements.txt` and raises a custom `ImportError` when the GDAL-specific code is invoked.

**BONUS FIX:** Apparently the Github action pipelines were failing, too, because the ubuntugis ppa is incompatible with the latest ubuntu version. I pegged the test pipeline to use ubuntu-22.04, it works for now, although it certainly won't stay that way forever.