### PR TITLE
Making gdal, seaborn and matplotlib as a optional dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+test.ipynb
 
 # IPython
 profile_default/

--- a/docs/source/how_to_use.rst
+++ b/docs/source/how_to_use.rst
@@ -131,6 +131,9 @@ You can create a layer group from layers that have been uploaded previously with
 Uploading and publishing styles
 -------------------------------
 
+**WARNING:** As of version 2.9.0, the required dependency ``gdal``, ``matplotlib`` and ``seaborn`` was converted into an optional dependency. Fresh installations of this library will require that you then install ``gdal``, ``matplotlib`` and ``seaborn`` yourself with ``pip install gdal matplotlib seaborn``.
+
+
 It is used for uploading ``SLD`` files and publish style. If the style name already exists, you can pass the parameter ``overwrite=True`` to overwrite it. The name of the style will be name of the uploaded file name.
 
 Before uploading ``SLD`` file, please check the version of your sld file. By default the version of sld will be ``1.0.0``. As I noticed, by default the QGIS will provide the .sld file of version ``1.0.0`` for raster data version ``1.1.0`` for vector data.
@@ -227,6 +230,8 @@ For generating the style for ``classified raster``, you can pass the another par
 
 Creating feature styles
 -----------------------
+
+**WARNING:** As of version 2.9.0, the required dependency ``gdal``, ``matplotlib`` and ``seaborn`` was converted into an optional dependency. Fresh installations of this library will require that you then install ``gdal``, ``matplotlib`` and ``seaborn`` yourself with ``pip install gdal matplotlib seaborn``.
 
 It is used for creating the style for ``point``, ``line`` and ``polygon`` dynamically. It currently supports three different types of feature styles:
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,8 +23,13 @@ The ``geoserver-rest`` library can be installed using ``pip`` as below:
 
     $ pip install geoserver-rest
 
+But best way to get all the functationality is to install the optional dependencies as well:
 
-If you want to install the geoserver-rest library with the optional dependencies, you need to install the following dependencies first:
+.. code-block:: shell
+
+    $ pip install geoserver-rest[all]
+
+If you want to install the geoserver-rest library with the optional dependencies (this will be useful if you are planning to create dynamic style files based on your dataset. Explore ``create_coveragestyle``, ``upload_style`` etc functions), you need to install the following dependencies first:
 
 * `GDAL <https://gdal.org/>`_
 * `matplotlib <https://matplotlib.org/>`_

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,7 +12,7 @@ The ``geoserver-rest`` can be installed from either ``conda-forge`` channel as b
 
 .. code-block:: shell
 
-    $ conda install -c conda-forge geoserver-rest
+    $ conda install -c conda-forge geoserver-rest[all]
 
 Pip installation
 ^^^^^^^^^^^^^^^^
@@ -48,8 +48,6 @@ One way is install the wheel directly from the `Geospatial library wheels for Py
     $ pip.exe install seaborn matplotlib
 
 Another way is to use the GDAL network installer binary package available at: `OSGeo4W <https://trac.osgeo.org/osgeo4w/>`_.
-
-
 
 
 macOS installation

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,6 +1,10 @@
 Installation
 =============
 
+.. warning::
+    As of version 2.9.0, the required dependency ``gdal``, ``matplotlib`` and ``seaborn`` was converted into an optional dependency. Fresh installations of this library will require that you then install ``gdal``, ``matplotlib`` and ``seaborn`` yourself with ``pip install gdal matplotlib seaborn``.
+
+
 Conda installation
 ^^^^^^^^^^^^^^^^^^
 
@@ -8,17 +12,27 @@ The ``geoserver-rest`` can be installed from either ``conda-forge`` channel as b
 
 .. code-block:: shell
 
-    conda install -c conda-forge geoserver-rest
+    $ conda install -c conda-forge geoserver-rest
 
 Pip installation
 ^^^^^^^^^^^^^^^^
 
-For installation of this package, following packages should be installed first:
+The ``geoserver-rest`` library can be installed using ``pip`` as below:
+
+.. code-block:: shell
+
+    $ pip install geoserver-rest
+
+
+If you want to install the geoserver-rest library with the optional dependencies, you need to install the following dependencies first:
 
 * `GDAL <https://gdal.org/>`_
+* `matplotlib <https://matplotlib.org/>`_
+* `seaborn <https://seaborn.pydata.org/>`_
 
-Windows installation
---------------------
+
+Dependencies installation in Windows
+------------------------------------
 
 .. warning::
     As of March 2022, ``pipwin`` has been deprecated and is no longer maintained. Do not use this method.
@@ -31,14 +45,12 @@ One way is install the wheel directly from the `Geospatial library wheels for Py
 
     # For Python3.10 on Windows 64-bit systems
     $ pip.exe install https://github.com/cgohlke/geospatial-wheels/releases/download/<release_version>/GDAL-3.7.1-cp310-cp310-win_amd64.whl
+    $ pip.exe install seaborn matplotlib
 
 Another way is to use the GDAL network installer binary package available at: `OSGeo4W <https://trac.osgeo.org/osgeo4w/>`_.
 
-Now you can then install ``geoserver-rest`` library with ``pip``:
 
-.. code-block:: shell
 
-    $ pip install geoserver-rest
 
 macOS installation
 ------------------

--- a/geo/Geoserver.py
+++ b/geo/Geoserver.py
@@ -8,7 +8,6 @@ import requests
 from xmltodict import parse, unparse
 
 # custom functions
-from .Style import catagorize_xml, classified_xml, coverage_style_xml, outline_only_xml
 from .supports import prepare_zip_file, is_valid_xml, is_surrounded_by_quotes
 
 
@@ -1612,6 +1611,7 @@ class Geoserver:
         """
 
         from .Calculation_gdal import raster_value
+        from .Style import coverage_style_xml
 
         raster = raster_value(raster_path)
         min_value = raster["min"]
@@ -1708,6 +1708,9 @@ class Geoserver:
         Inputs: column_name (based on which column style should be generated), workspace,
         color_or_ramp (color should be provided in hex code or the color ramp name, geom_type(point, line, polygon), outline_color(hex_color))
         """
+        
+        from .Style import catagorize_xml
+
         catagorize_xml(column_name, column_distinct_values, color_ramp, geom_type)
 
         style_xml = "<style><name>{}</name><filename>{}</filename></style>".format(
@@ -1782,6 +1785,9 @@ class Geoserver:
         The geometry type must be point, line or polygon
         Inputs: style_name (name of the style file in geoserver), workspace, color (style color)
         """
+
+        from .Style import outline_only_xml
+
         outline_only_xml(color, width, geom_type)
 
         style_xml = "<style><name>{}</name><filename>{}</filename></style>".format(
@@ -1863,6 +1869,8 @@ class Geoserver:
         Inputs: column_name (based on which column style should be generated), workspace,
         color_or_ramp (color should be provided in hex code or the color ramp name, geom_type(point, line, polygon), outline_color(hex_color))
         """
+
+        from .Style import classified_xml
         classified_xml(
             style_name,
             column_name,

--- a/geo/__init__.py
+++ b/geo/__init__.py
@@ -1,1 +1,1 @@
-from . import Calculation_gdal, Style
+

--- a/geo/__version__.py
+++ b/geo/__version__.py
@@ -4,4 +4,4 @@
 
 __author__ = "Tek Kshetri"
 __email__ = "iamtekson@gmail.com"
-__version__ = "2.9.0"
+__version__ = "2.9.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 pygments
 requests
-seaborn
-matplotlib
 xmltodict

--- a/requirements_style.txt
+++ b/requirements_style.txt
@@ -1,0 +1,3 @@
+matplotlib
+seaborn
+gdal

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
         "requests",
         "xmltodict",
     ],
-    extras_require={"dev": ["pytest", "black", "flake8", "sphinx>=1.7", "pre-commit"], 'style': ['matplotlib', 'seaborn', 'gdal']},
+    extras_require={"dev": ["pytest", "black", "flake8", "sphinx>=1.7", "pre-commit"], 'style': ['matplotlib', 'seaborn', 'gdal'], 'all': ['matplotlib', 'seaborn', 'gdal']},
     python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,8 @@ setup(
     install_requires=[
         "pygments",
         "requests",
-        "seaborn",
-        "gdal",
-        "matplotlib",
         "xmltodict",
     ],
-    extras_require={"dev": ["pytest", "black", "flake8", "sphinx>=1.7", "pre-commit"]},
+    extras_require={"dev": ["pytest", "black", "flake8", "sphinx>=1.7", "pre-commit"], 'visualize': ['matplotlib', 'seaborn', 'gdal']},
     python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
         "requests",
         "xmltodict",
     ],
-    extras_require={"dev": ["pytest", "black", "flake8", "sphinx>=1.7", "pre-commit"], 'visualize': ['matplotlib', 'seaborn', 'gdal']},
+    extras_require={"dev": ["pytest", "black", "flake8", "sphinx>=1.7", "pre-commit"], 'style': ['matplotlib', 'seaborn', 'gdal']},
     python_requires=">=3.6",
 )


### PR DESCRIPTION
The `gdal`, `seaborn` and `matplotlib` packages were only used for creating the style file for raster and vector data in geoserver. In the newer version, we make those as a dependency package, those can be installed via,

```shell
pip install geoserver-rest[style]
```